### PR TITLE
Add K8s PVC manifest template

### DIFF
--- a/templates/pvc.yaml.tpl
+++ b/templates/pvc.yaml.tpl
@@ -1,0 +1,21 @@
+# Kubernetes PersistentVolumeClaim Template for User Projects
+#
+# Template Variables:
+#   {{namespace}}   - Kubernetes namespace (e.g., `a1b2c3-myapp`)
+#   {{serviceName}} - Service name for the PVC
+#   {{storageGb}}   - Storage size in GB (1-10)
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{serviceName}}-data"
+  namespace: "{{namespace}}"
+  labels:
+    app: "{{serviceName}}"
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "{{storageGb}}Gi"


### PR DESCRIPTION
## Summary
- Create `templates/pvc.yaml.tpl` for optional persistent storage allocation
- Uses Longhorn storage class with ReadWriteOnce access mode
- Supports configurable storage size (1-10 GB)
- Documented all template variables in file header

## Test plan
- [ ] Verify template syntax is valid YAML
- [ ] Confirm template variables match issue specification

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)