### PR TITLE
Add K8s service and ingress manifest templates

### DIFF
--- a/templates/ingress.yaml.tpl
+++ b/templates/ingress.yaml.tpl
@@ -1,0 +1,26 @@
+# Kubernetes Ingress Template for User Projects
+#
+# Template Variables:
+#   {{namespace}}   - Kubernetes namespace (e.g., `a1b2c3-myapp`)
+#   {{serviceName}} - Service name
+#   {{port}}        - Service port number
+#   {{subdomain}}   - Subdomain prefix (e.g., `a1b2c3-myservice`)
+#   {{baseDomain}}  - Base domain (e.g., `192.168.1.124.nip.io`)
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{serviceName}}"
+  namespace: "{{namespace}}"
+spec:
+  rules:
+    - host: "{{subdomain}}.{{baseDomain}}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "{{serviceName}}"
+                port:
+                  number: {{port}}

--- a/templates/service.yaml.tpl
+++ b/templates/service.yaml.tpl
@@ -1,0 +1,19 @@
+# Kubernetes Service Template for User Projects
+#
+# Template Variables:
+#   {{namespace}}   - Kubernetes namespace (e.g., `a1b2c3-myapp`)
+#   {{serviceName}} - Service name
+#   {{port}}        - Container/service port
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{serviceName}}"
+  namespace: "{{namespace}}"
+spec:
+  type: ClusterIP
+  selector:
+    app: "{{serviceName}}"
+  ports:
+    - port: {{port}}
+      targetPort: {{port}}


### PR DESCRIPTION
## Summary
- Create `templates/service.yaml.tpl` for ClusterIP services with port mapping
- Create `templates/ingress.yaml.tpl` for host-based routing to subdomains
- Document all template variables in file headers

## Template Variables
- `{{namespace}}` - Kubernetes namespace
- `{{serviceName}}` - Service name
- `{{port}}` - Container/service port
- `{{subdomain}}` - Subdomain prefix
- `{{baseDomain}}` - Base domain

## Test plan
- [ ] Verify service template renders correctly with placeholder values
- [ ] Verify ingress template renders correctly with placeholder values
- [ ] Confirm templates match Traefik ingress requirements

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)