### PR TITLE
Add K8s deployment manifest template

### DIFF
--- a/templates/deployment.yaml.tpl
+++ b/templates/deployment.yaml.tpl
@@ -1,0 +1,93 @@
+# Kubernetes Deployment Template for User Services
+#
+# Template Variables:
+#   {{namespace}}        - Kubernetes namespace for the deployment
+#   {{serviceName}}      - Name of the service (used for deployment, labels, selectors)
+#   {{image}}            - Full container image path with tag (e.g., registry/app:v1.0.0)
+#   {{port}}             - Container port to expose
+#   {{envVars}}          - Array of environment variables [{name, value}]
+#   {{healthCheckPath}}  - Optional: HTTP path for health check probe (e.g., /health)
+#   {{storageMountPath}} - Optional: Mount path for PVC (default: /data when enabled)
+#   {{storageClaimName}} - Optional: PVC name if persistent storage is enabled
+#
+# Resource Defaults:
+#   Memory: 256Mi (request and limit)
+#   CPU: 250m (request and limit)
+#
+# Update Strategy:
+#   Rolling update with maxSurge: 1, maxUnavailable: 0
+#   Ensures zero-downtime deployments
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{serviceName}}
+  namespace: {{namespace}}
+  labels:
+    app: {{serviceName}}
+    managed-by: dangus-cloud
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: {{serviceName}}
+  template:
+    metadata:
+      labels:
+        app: {{serviceName}}
+    spec:
+      containers:
+        - name: {{serviceName}}
+          image: {{image}}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: {{port}}
+              protocol: TCP
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          {{#envVars}}
+          env:
+            {{#each envVars}}
+            - name: {{name}}
+              value: "{{value}}"
+            {{/each}}
+          {{/envVars}}
+          {{#healthCheckPath}}
+          livenessProbe:
+            httpGet:
+              path: {{healthCheckPath}}
+              port: {{port}}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{healthCheckPath}}
+              port: {{port}}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{/healthCheckPath}}
+          {{#storageClaimName}}
+          volumeMounts:
+            - name: data-volume
+              mountPath: {{storageMountPath}}
+          {{/storageClaimName}}
+      {{#storageClaimName}}
+      volumes:
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: {{storageClaimName}}
+      {{/storageClaimName}}


### PR DESCRIPTION
## Summary
- Create `templates/deployment.yaml.tpl` for user service deployments
- Support all required template variables (namespace, serviceName, image, port, envVars)
- Include optional health check probes (liveness and readiness)
- Include optional PVC volume mount for persistent storage
- Set resource limits (256Mi memory, 250m CPU)
- Add rolling update strategy (maxSurge 1, maxUnavailable 0)

## Test plan
- [ ] Verify template renders correctly with all variables populated
- [ ] Test with optional healthCheckPath enabled
- [ ] Test with optional storage (storageClaimName) enabled
- [ ] Validate generated YAML against Kubernetes schema

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)