### PR TITLE
Add K8s manifest generation utilities

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "@octokit/rest": "^20.0.2",
     "fastify": "^4.24.3",
     "fastify-plugin": "^4.5.1",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/backend/src/services/manifestGenerator.js
+++ b/backend/src/services/manifestGenerator.js
@@ -1,0 +1,236 @@
+import { readFileSync } from 'fs';
+import { parse } from 'yaml';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = join(__dirname, '../../../templates');
+
+/**
+ * Interpolate template variables using mustache-style syntax.
+ * Supports:
+ *   - Simple variables: {{variable}}
+ *   - Conditional blocks: {{#variable}}content{{/variable}}
+ *   - Each loops: {{#each items}}...{{name}}...{{/each}}
+ *
+ * @param {string} template - Template string with {{variable}} placeholders
+ * @param {object} vars - Object containing variable values
+ * @returns {string} Interpolated template string
+ */
+function interpolate(template, vars) {
+  let result = template;
+
+  // Handle {{#each items}}...{{/each}} loops
+  result = result.replace(
+    /\{\{#each\s+(\w+)\}\}([\s\S]*?)\{\{\/each\}\}/g,
+    (_, arrayName, content) => {
+      const items = vars[arrayName];
+      if (!items || !Array.isArray(items) || items.length === 0) {
+        return '';
+      }
+      return items.map(item => {
+        let itemContent = content;
+        for (const [key, value] of Object.entries(item)) {
+          itemContent = itemContent.replace(
+            new RegExp(`\\{\\{${key}\\}\\}`, 'g'),
+            String(value)
+          );
+        }
+        return itemContent;
+      }).join('');
+    }
+  );
+
+  // Handle {{#variable}}...{{/variable}} conditional blocks
+  result = result.replace(
+    /\{\{#(\w+)\}\}([\s\S]*?)\{\{\/\1\}\}/g,
+    (_, varName, content) => {
+      const value = vars[varName];
+      if (!value) {
+        return '';
+      }
+      // Recursively interpolate the content inside the block
+      return interpolate(content, vars);
+    }
+  );
+
+  // Handle simple {{variable}} replacements
+  result = result.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    if (!(key in vars)) {
+      throw new Error(`Missing required variable: ${key}`);
+    }
+    return String(vars[key]);
+  });
+
+  return result;
+}
+
+/**
+ * Load a template file from the templates directory
+ * @param {string} filename - Template filename (e.g., 'deployment.yaml.tpl')
+ * @returns {string} Template content
+ */
+function loadTemplate(filename) {
+  const templatePath = join(TEMPLATES_DIR, filename);
+  return readFileSync(templatePath, 'utf8');
+}
+
+/**
+ * Generate a Kubernetes Namespace manifest
+ * @param {string} name - Full namespace name (e.g., 'a1b2c3-myapp')
+ * @returns {object} Parsed Kubernetes manifest object
+ */
+export function generateNamespaceManifest(name) {
+  // Extract userHash and projectName from namespace name
+  const parts = name.split('-');
+  if (parts.length < 2) {
+    throw new Error('Namespace name must be in format: userHash-projectName');
+  }
+  const userHash = parts[0];
+  const projectName = parts.slice(1).join('-');
+
+  const template = loadTemplate('namespace.yaml.tpl');
+  const yaml = interpolate(template, {
+    namespace: name,
+    userHash,
+    projectName
+  });
+  return parse(yaml);
+}
+
+/**
+ * Generate a Kubernetes Deployment manifest
+ * @param {object} options - Deployment configuration
+ * @param {string} options.namespace - Kubernetes namespace
+ * @param {string} options.serviceName - Name of the service
+ * @param {string} options.image - Full container image path with tag
+ * @param {number} options.port - Container port to expose
+ * @param {Array<{name: string, value: string}>} [options.envVars] - Environment variables
+ * @param {string} [options.healthCheckPath] - HTTP path for health check probe
+ * @param {string} [options.storageMountPath] - Mount path for PVC (default: /data)
+ * @param {string} [options.storageClaimName] - PVC name if persistent storage is enabled
+ * @returns {object} Parsed Kubernetes manifest object
+ */
+export function generateDeploymentManifest(options) {
+  const required = ['namespace', 'serviceName', 'image', 'port'];
+  for (const field of required) {
+    if (!(field in options)) {
+      throw new Error(`Missing required option: ${field}`);
+    }
+  }
+
+  // Set default storageMountPath if storageClaimName is provided
+  if (options.storageClaimName && !options.storageMountPath) {
+    options.storageMountPath = '/data';
+  }
+
+  const template = loadTemplate('deployment.yaml.tpl');
+  const yaml = interpolate(template, options);
+  return parse(yaml);
+}
+
+/**
+ * Generate a Kubernetes Service manifest
+ * @param {object} options - Service configuration
+ * @param {string} options.namespace - Kubernetes namespace
+ * @param {string} options.serviceName - Service name
+ * @param {number} options.port - Container/service port
+ * @returns {object} Parsed Kubernetes manifest object
+ */
+export function generateServiceManifest(options) {
+  const required = ['namespace', 'serviceName', 'port'];
+  for (const field of required) {
+    if (!(field in options)) {
+      throw new Error(`Missing required option: ${field}`);
+    }
+  }
+
+  const template = loadTemplate('service.yaml.tpl');
+  const yaml = interpolate(template, options);
+  return parse(yaml);
+}
+
+/**
+ * Generate a Kubernetes Ingress manifest
+ * @param {object} options - Ingress configuration
+ * @param {string} options.namespace - Kubernetes namespace
+ * @param {string} options.serviceName - Service name
+ * @param {number} options.port - Service port number
+ * @param {string} options.subdomain - Subdomain prefix (e.g., 'a1b2c3-myservice')
+ * @param {string} options.baseDomain - Base domain (e.g., '192.168.1.124.nip.io')
+ * @returns {object} Parsed Kubernetes manifest object
+ */
+export function generateIngressManifest(options) {
+  const required = ['namespace', 'serviceName', 'port', 'subdomain', 'baseDomain'];
+  for (const field of required) {
+    if (!(field in options)) {
+      throw new Error(`Missing required option: ${field}`);
+    }
+  }
+
+  const template = loadTemplate('ingress.yaml.tpl');
+  const yaml = interpolate(template, options);
+  return parse(yaml);
+}
+
+/**
+ * Generate a Kubernetes PersistentVolumeClaim manifest
+ * @param {object} options - PVC configuration
+ * @param {string} options.namespace - Kubernetes namespace
+ * @param {string} options.serviceName - Service name for the PVC
+ * @param {number} options.storageGb - Storage size in GB (1-10)
+ * @returns {object} Parsed Kubernetes manifest object
+ */
+export function generatePVCManifest(options) {
+  const required = ['namespace', 'serviceName', 'storageGb'];
+  for (const field of required) {
+    if (!(field in options)) {
+      throw new Error(`Missing required option: ${field}`);
+    }
+  }
+
+  if (options.storageGb < 1 || options.storageGb > 10) {
+    throw new Error('storageGb must be between 1 and 10');
+  }
+
+  const template = loadTemplate('pvc.yaml.tpl');
+  const yaml = interpolate(template, options);
+  return parse(yaml);
+}
+
+/**
+ * Generate a Kubernetes Job manifest for Kaniko Docker image builds
+ * @param {object} options - Kaniko job configuration
+ * @param {string} options.namespace - Kubernetes namespace for the job
+ * @param {string} options.jobName - Unique job name (should include timestamp or commit SHA)
+ * @param {string} options.repoUrl - GitHub repository URL (e.g., github.com/owner/repo)
+ * @param {string} options.branch - Git branch to build from
+ * @param {string} options.commitSha - Specific commit SHA to build
+ * @param {string} options.dockerfilePath - Path to Dockerfile (e.g., ./Dockerfile)
+ * @param {string} options.imageDest - Full destination image path
+ * @param {string} options.gitSecretName - Name of K8s secret containing git credentials
+ * @param {string} options.registrySecretName - Name of K8s secret containing registry credentials
+ * @returns {object} Parsed Kubernetes manifest object
+ */
+export function generateKanikoJobManifest(options) {
+  const required = [
+    'namespace',
+    'jobName',
+    'repoUrl',
+    'branch',
+    'commitSha',
+    'dockerfilePath',
+    'imageDest',
+    'gitSecretName',
+    'registrySecretName'
+  ];
+  for (const field of required) {
+    if (!(field in options)) {
+      throw new Error(`Missing required option: ${field}`);
+    }
+  }
+
+  const template = loadTemplate('kaniko-job.yaml.tpl');
+  const yaml = interpolate(template, options);
+  return parse(yaml);
+}


### PR DESCRIPTION
## Summary
- Creates `backend/src/services/manifestGenerator.js` with template loading from `templates/` directory
- Implements mustache-style variable interpolation (`{{variable}}`) with support for conditional blocks and each loops
- Adds generate functions for all K8s resource types: Namespace, Deployment, Service, Ingress, PVC, and Kaniko Job
- Validates required variables and returns parsed YAML as JavaScript objects
- Adds `yaml` package dependency for YAML parsing

## Test plan
- [ ] Verify template loading from `templates/` directory
- [ ] Test variable interpolation with simple variables
- [ ] Test conditional blocks render/hide correctly based on variable presence
- [ ] Test each loops iterate over arrays correctly
- [ ] Test generateNamespaceManifest with valid namespace name
- [ ] Test generateDeploymentManifest with required and optional options
- [ ] Test generateServiceManifest with required options
- [ ] Test generateIngressManifest with required options
- [ ] Test generatePVCManifest with valid storageGb range
- [ ] Test generateKanikoJobManifest with all required options
- [ ] Verify error thrown for missing required variables

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)