### PR TITLE
Add terminal-styled form input and button components

### DIFF
--- a/frontend/src/components/TerminalButton.jsx
+++ b/frontend/src/components/TerminalButton.jsx
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Terminal-styled button component with variants
+ * Variants: primary (green), secondary (amber), danger (red)
+ */
+const TerminalButton = ({
+  children,
+  variant = 'primary',
+  disabled = false,
+  onClick,
+  type = 'button',
+  className = '',
+  ...props
+}) => {
+  const variantStyles = {
+    primary: {
+      border: 'border-[var(--color-accent-green)]',
+      text: 'text-[var(--color-accent-green)]',
+      hover: 'hover:bg-[var(--color-accent-green)] hover:text-[var(--color-bg-primary)] hover:shadow-[var(--glow-green)]',
+    },
+    secondary: {
+      border: 'border-[var(--color-accent-amber)]',
+      text: 'text-[var(--color-accent-amber)]',
+      hover: 'hover:bg-[var(--color-accent-amber)] hover:text-[var(--color-bg-primary)] hover:shadow-[var(--glow-amber)]',
+    },
+    danger: {
+      border: 'border-[var(--color-accent-red)]',
+      text: 'text-[var(--color-accent-red)]',
+      hover: 'hover:bg-[var(--color-accent-red)] hover:text-[var(--color-bg-primary)] hover:shadow-[var(--glow-red)]',
+    },
+  };
+
+  const styles = variantStyles[variant] || variantStyles.primary;
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`
+        bg-transparent
+        border
+        ${styles.border}
+        ${styles.text}
+        px-4 py-2
+        font-mono text-sm
+        uppercase
+        tracking-[2px]
+        cursor-pointer
+        transition-all duration-150
+        ${!disabled ? styles.hover : ''}
+        ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+        ${className}
+      `}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+TerminalButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  variant: PropTypes.oneOf(['primary', 'secondary', 'danger']),
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  className: PropTypes.string,
+};
+
+export default TerminalButton;

--- a/frontend/src/components/TerminalInput.jsx
+++ b/frontend/src/components/TerminalInput.jsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Terminal-styled input component with prompt prefix and blinking cursor animation
+ */
+const TerminalInput = ({
+  value,
+  onChange,
+  placeholder = 'Enter text...',
+  disabled = false,
+  type = 'text',
+  name,
+  id,
+  className = '',
+  ...props
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <div
+      className={`
+        relative flex items-center
+        bg-[var(--color-bg-secondary)]
+        border border-[var(--color-border)]
+        transition-all duration-150
+        ${isFocused ? 'border-[var(--color-accent-green)] shadow-[var(--glow-green)]' : ''}
+        ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+        ${className}
+      `}
+    >
+      <span className="text-[var(--color-text-muted)] px-2 select-none font-mono">
+        {'>'}
+      </span>
+      <input
+        type={type}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        name={name}
+        id={id}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        className={`
+          flex-1 bg-transparent
+          text-[var(--color-text-primary)]
+          font-mono text-sm
+          py-2 pr-3
+          outline-none
+          placeholder:text-[var(--color-text-muted)]
+          disabled:cursor-not-allowed
+          ${isFocused ? 'caret-[var(--color-accent-green)]' : ''}
+        `}
+        style={{
+          caretColor: 'var(--color-accent-green)',
+        }}
+        {...props}
+      />
+      {isFocused && (
+        <span
+          className="absolute right-3 w-2 h-4 bg-[var(--color-accent-green)] animate-pulse"
+          style={{
+            animation: 'blink 1s step-end infinite',
+          }}
+        />
+      )}
+      <style>{`
+        @keyframes blink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+TerminalInput.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
+  type: PropTypes.string,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default TerminalInput;

--- a/frontend/src/components/TerminalSelect.jsx
+++ b/frontend/src/components/TerminalSelect.jsx
@@ -1,0 +1,158 @@
+import { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Terminal-styled select/dropdown component with arrow indicator
+ */
+const TerminalSelect = ({
+  options = [],
+  value,
+  onChange,
+  placeholder = 'Select...',
+  disabled = false,
+  name,
+  id,
+  className = '',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const selectRef = useRef(null);
+
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (selectRef.current && !selectRef.current.contains(event.target)) {
+        setIsOpen(false);
+        setIsFocused(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (optionValue) => {
+    onChange?.({ target: { name, value: optionValue } });
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event) => {
+    if (disabled) return;
+
+    switch (event.key) {
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        setIsOpen(!isOpen);
+        break;
+      case 'Escape':
+        setIsOpen(false);
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+        } else {
+          const currentIndex = options.findIndex((opt) => opt.value === value);
+          const nextIndex = Math.min(currentIndex + 1, options.length - 1);
+          handleSelect(options[nextIndex].value);
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (isOpen) {
+          const currentIndex = options.findIndex((opt) => opt.value === value);
+          const prevIndex = Math.max(currentIndex - 1, 0);
+          handleSelect(options[prevIndex].value);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div
+      ref={selectRef}
+      className={`relative ${className}`}
+      id={id}
+    >
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => !isOpen && setIsFocused(false)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={`
+          w-full flex items-center justify-between
+          bg-[var(--color-bg-secondary)]
+          border border-[var(--color-border)]
+          text-left
+          px-3 py-2
+          font-mono text-sm
+          transition-all duration-150
+          ${isFocused || isOpen ? 'border-[var(--color-accent-green)] shadow-[var(--glow-green)]' : ''}
+          ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+        `}
+      >
+        <span className={selectedOption ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-muted)]'}>
+          {selectedOption ? selectedOption.label : placeholder}
+        </span>
+        <span className="text-[var(--color-text-muted)] ml-2">
+          {isOpen ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          className="
+            absolute z-50 w-full mt-1
+            bg-[var(--color-bg-secondary)]
+            border border-[var(--color-accent-green)]
+            shadow-[var(--glow-green)]
+            max-h-48 overflow-y-auto
+          "
+        >
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => handleSelect(option.value)}
+              className={`
+                w-full text-left px-3 py-2
+                font-mono text-sm
+                transition-colors duration-100
+                ${option.value === value
+                  ? 'bg-[var(--color-accent-green)] text-[var(--color-bg-primary)]'
+                  : 'text-[var(--color-text-primary)] hover:bg-[var(--color-bg-elevated)]'
+                }
+              `}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+TerminalSelect.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default TerminalSelect;

--- a/frontend/src/components/TerminalSlider.jsx
+++ b/frontend/src/components/TerminalSlider.jsx
@@ -1,0 +1,145 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Terminal-styled slider component for storage allocation
+ * Displays: [████████░░░░] 8 GB
+ */
+const TerminalSlider = ({
+  value = 1,
+  onChange,
+  min = 1,
+  max = 10,
+  step = 1,
+  unit = 'GB',
+  disabled = false,
+  name,
+  id,
+  label,
+  className = '',
+}) => {
+  const totalBars = 12;
+  const filledBars = Math.round(((value - min) / (max - min)) * totalBars);
+  const emptyBars = totalBars - filledBars;
+
+  const progressDisplay = '█'.repeat(filledBars) + '░'.repeat(emptyBars);
+
+  const handleChange = (event) => {
+    const newValue = Number(event.target.value);
+    onChange?.({ target: { name, value: newValue } });
+  };
+
+  const handleKeyDown = (event) => {
+    if (disabled) return;
+
+    let newValue = value;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        event.preventDefault();
+        newValue = Math.min(value + step, max);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        event.preventDefault();
+        newValue = Math.max(value - step, min);
+        break;
+      case 'Home':
+        event.preventDefault();
+        newValue = min;
+        break;
+      case 'End':
+        event.preventDefault();
+        newValue = max;
+        break;
+      default:
+        return;
+    }
+
+    if (newValue !== value) {
+      onChange?.({ target: { name, value: newValue } });
+    }
+  };
+
+  return (
+    <div className={`flex flex-col gap-2 ${className}`}>
+      {label && (
+        <label
+          htmlFor={id}
+          className="font-mono text-sm text-[var(--color-text-muted)]"
+        >
+          {label}
+        </label>
+      )}
+      <div className="flex items-center gap-3">
+        <div
+          className={`
+            font-mono text-sm
+            px-2 py-1
+            border border-[var(--color-border)]
+            bg-[var(--color-bg-secondary)]
+            ${disabled ? 'opacity-50' : ''}
+          `}
+        >
+          <span className="text-[var(--color-accent-green)]">[</span>
+          <span className="text-[var(--color-accent-green)]">{progressDisplay}</span>
+          <span className="text-[var(--color-accent-green)]">]</span>
+        </div>
+        <span className="font-mono text-sm text-[var(--color-text-primary)] min-w-[60px]">
+          {value} {unit}
+        </span>
+      </div>
+      <input
+        type="range"
+        id={id}
+        name={name}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={`
+          w-full h-1
+          appearance-none
+          bg-[var(--color-border)]
+          cursor-pointer
+          ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+          [&::-webkit-slider-thumb]:appearance-none
+          [&::-webkit-slider-thumb]:w-3
+          [&::-webkit-slider-thumb]:h-3
+          [&::-webkit-slider-thumb]:bg-[var(--color-accent-green)]
+          [&::-webkit-slider-thumb]:border-none
+          [&::-webkit-slider-thumb]:cursor-pointer
+          [&::-webkit-slider-thumb]:shadow-[var(--glow-green)]
+          [&::-moz-range-thumb]:w-3
+          [&::-moz-range-thumb]:h-3
+          [&::-moz-range-thumb]:bg-[var(--color-accent-green)]
+          [&::-moz-range-thumb]:border-none
+          [&::-moz-range-thumb]:cursor-pointer
+          [&::-moz-range-thumb]:shadow-[var(--glow-green)]
+        `}
+      />
+      <div className="flex justify-between font-mono text-xs text-[var(--color-text-muted)]">
+        <span>{min} {unit}</span>
+        <span>{max} {unit}</span>
+      </div>
+    </div>
+  );
+};
+
+TerminalSlider.propTypes = {
+  value: PropTypes.number,
+  onChange: PropTypes.func,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  step: PropTypes.number,
+  unit: PropTypes.string,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default TerminalSlider;

--- a/frontend/src/components/TerminalToggle.jsx
+++ b/frontend/src/components/TerminalToggle.jsx
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Terminal-styled toggle component with [ ON ] / [OFF] style
+ */
+const TerminalToggle = ({
+  checked = false,
+  onChange,
+  disabled = false,
+  name,
+  id,
+  label,
+  className = '',
+}) => {
+  const handleClick = () => {
+    if (!disabled && onChange) {
+      onChange({ target: { name, checked: !checked } });
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (disabled) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleClick();
+    }
+  };
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        id={id}
+        className={`
+          font-mono text-sm
+          px-2 py-1
+          border
+          transition-all duration-150
+          ${checked
+            ? 'border-[var(--color-accent-green)] text-[var(--color-accent-green)] shadow-[var(--glow-green)]'
+            : 'border-[var(--color-border)] text-[var(--color-text-muted)]'
+          }
+          ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:border-[var(--color-accent-green)]'}
+        `}
+      >
+        {checked ? '[ ON ]' : '[OFF]'}
+      </button>
+      {label && (
+        <label
+          htmlFor={id}
+          className={`
+            font-mono text-sm cursor-pointer
+            ${checked ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-muted)]'}
+            ${disabled ? 'cursor-not-allowed' : ''}
+          `}
+          onClick={handleClick}
+        >
+          {label}
+        </label>
+      )}
+    </div>
+  );
+};
+
+TerminalToggle.propTypes = {
+  checked: PropTypes.bool,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default TerminalToggle;


### PR DESCRIPTION
## Summary
- Create reusable form components with terminal aesthetic
- Add TerminalInput with `>` prompt prefix, green glow on focus, and blinking cursor animation
- Add TerminalButton with primary (green), secondary (amber), and danger (red) variants
- Add TerminalSelect dropdown with arrow indicators (▼/▲) and keyboard navigation
- Add TerminalToggle with `[ ON ]` / `[OFF]` style display
- Add TerminalSlider for storage allocation with visual progress bar `[████████░░░░]`

## Test plan
- [ ] Import and render each component in a test page
- [ ] Verify TerminalInput shows prompt prefix and blinking cursor on focus
- [ ] Test TerminalButton hover states and all three variants
- [ ] Test TerminalSelect opens/closes and keyboard navigation works
- [ ] Verify TerminalToggle switches between ON/OFF states
- [ ] Test TerminalSlider updates value and progress bar correctly

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)