### PR TITLE
feat: Add terminal-themed Layout component with navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,25 +1,58 @@
 import { useState } from 'react'
 import {
-  AsciiLogo,
   AsciiBox,
   AsciiDivider,
   AsciiSectionDivider,
   StatusIndicator,
   StatusBar,
-  ProgressGauge
+  ProgressGauge,
+  Layout,
+  SidebarMenu
 } from './components'
 
 function App() {
   const [sectionCollapsed, setSectionCollapsed] = useState(false)
+  const [activeNav, setActiveNav] = useState('Dashboard')
+
+  const navItems = [
+    { label: 'Dashboard', href: '/', active: activeNav === 'Dashboard' },
+    { label: 'Projects', href: '/projects', active: activeNav === 'Projects' },
+    { label: 'Settings', href: '/settings', active: activeNav === 'Settings' },
+    { label: 'Logout', href: '/logout', active: activeNav === 'Logout' }
+  ]
+
+  const sidebarMenuItems = [
+    { label: 'Overview', active: true },
+    { label: 'Deployments' },
+    { label: 'Monitoring' },
+    { label: 'Logs' },
+    { label: 'Configuration' }
+  ]
+
+  const handleNavClick = (item) => {
+    setActiveNav(item.label)
+  }
+
+  const sidebarContent = (
+    <SidebarMenu
+      items={sidebarMenuItems}
+      onItemClick={(item) => console.log('Sidebar item clicked:', item.label)}
+    />
+  )
 
   return (
-    <div className="min-h-screen bg-terminal-primary p-8">
-      {/* ASCII Logo Demo */}
-      <header className="mb-8">
-        <AsciiLogo showBorder={true} glowColor="green" />
-      </header>
-
-      <main className="space-y-8">
+    <Layout
+      navItems={navItems}
+      onNavClick={handleNavClick}
+      breadcrumbs={[
+        { label: 'projects', href: '/projects' },
+        { label: 'myapp' },
+        { label: 'backend' }
+      ]}
+      sidebarContent={sidebarContent}
+      systemStatus="online"
+    >
+      <div className="space-y-8">
         {/* Status Bar Demo */}
         <StatusBar
           items={[
@@ -167,16 +200,8 @@ function App() {
             />
           </div>
         </section>
-      </main>
-
-      <footer className="mt-8 pt-4 terminal-border text-terminal-muted text-sm">
-        <StatusBar
-          items={[
-            { status: 'online', label: 'All systems operational', showLabel: true }
-          ]}
-        />
-      </footer>
-    </div>
+      </div>
+    </Layout>
   )
 }
 

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,328 @@
+import { useState, useEffect, useCallback } from 'react'
+import { AsciiLogo } from './AsciiLogo'
+import { StatusIndicator } from './StatusIndicator'
+import { AsciiDivider } from './AsciiDivider'
+
+export function Layout({
+  children,
+  breadcrumbs = [],
+  showSidebar = true,
+  sidebarContent = null,
+  systemStatus = 'online',
+  navItems = [
+    { label: 'Dashboard', href: '/', active: true },
+    { label: 'Projects', href: '/projects' },
+    { label: 'Settings', href: '/settings' },
+    { label: 'Logout', href: '/logout' }
+  ],
+  onNavClick = () => {},
+  showKeyboardHints = true,
+  className = ''
+}) {
+  const [currentTime, setCurrentTime] = useState(new Date())
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+
+  // Update time every second
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentTime(new Date())
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [])
+
+  // Check for mobile viewport
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768)
+    }
+    checkMobile()
+    window.addEventListener('resize', checkMobile)
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback((e) => {
+    // Alt + number keys for nav items
+    if (e.altKey && e.key >= '1' && e.key <= '9') {
+      const index = parseInt(e.key) - 1
+      if (navItems[index]) {
+        e.preventDefault()
+        onNavClick(navItems[index])
+      }
+    }
+    // Alt + S to toggle sidebar
+    if (e.altKey && e.key.toLowerCase() === 's') {
+      e.preventDefault()
+      setSidebarCollapsed(prev => !prev)
+    }
+  }, [navItems, onNavClick])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  const formatTimestamp = (date) => {
+    return date.toISOString().replace('T', ' ').substring(0, 19)
+  }
+
+  const systemStatusText = {
+    online: 'OPERATIONAL',
+    offline: 'OFFLINE',
+    error: 'ERROR',
+    warning: 'DEGRADED',
+    loading: 'INITIALIZING'
+  }
+
+  return (
+    <div className={`min-h-screen bg-terminal-primary flex flex-col terminal-grid-bg ${className}`}>
+      {/* Header */}
+      <header className="border-b border-terminal-border">
+        {/* Top bar with logo and system status */}
+        <div className="flex items-start justify-between px-4 py-3 md:px-6 md:py-4">
+          {/* ASCII Logo */}
+          <div className="flex-shrink-0">
+            <AsciiLogo
+              variant="full"
+              showBorder={!isMobile}
+              showCloud={!isMobile}
+              glowColor="green"
+            />
+          </div>
+
+          {/* System Status */}
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-2 text-sm font-mono">
+              <span className="text-terminal-muted uppercase tracking-terminal-wide">
+                SYSTEM:
+              </span>
+              <StatusIndicator
+                status={systemStatus}
+                label={systemStatusText[systemStatus] || 'UNKNOWN'}
+                size="sm"
+              />
+            </div>
+            {!isMobile && (
+              <div className="text-terminal-muted text-xs font-mono">
+                {formatTimestamp(currentTime)}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Navigation bar */}
+        <nav
+          className="px-4 py-2 md:px-6 border-t border-terminal-border bg-terminal-bg-secondary"
+          role="navigation"
+          aria-label="Main navigation"
+        >
+          <div className="flex items-center gap-1 md:gap-2 flex-wrap">
+            {navItems.map((item, index) => (
+              <span key={item.label} className="inline-flex items-center">
+                <button
+                  onClick={() => onNavClick(item)}
+                  className={`
+                    font-mono text-sm md:text-base transition-terminal-fast
+                    ${item.active
+                      ? 'text-terminal-primary text-glow-green'
+                      : 'text-terminal-secondary hover:text-terminal-primary'
+                    }
+                  `}
+                  aria-current={item.active ? 'page' : undefined}
+                >
+                  [ {item.label} ]
+                </button>
+                {index < navItems.length - 1 && (
+                  <span className="text-terminal-muted mx-1" aria-hidden="true">
+                    -
+                  </span>
+                )}
+              </span>
+            ))}
+
+            {/* Keyboard hint */}
+            {showKeyboardHints && !isMobile && (
+              <span className="ml-auto text-terminal-muted text-xs font-mono hidden lg:inline">
+                Alt+1-{Math.min(navItems.length, 9)} to navigate
+              </span>
+            )}
+          </div>
+        </nav>
+
+        {/* Breadcrumb navigation */}
+        {breadcrumbs.length > 0 && (
+          <div className="px-4 py-2 md:px-6 border-t border-terminal-border">
+            <nav aria-label="Breadcrumb" className="font-mono text-sm">
+              <ol className="flex items-center gap-1 flex-wrap">
+                <li>
+                  <span className="text-terminal-primary">root</span>
+                </li>
+                {breadcrumbs.map((crumb, index) => (
+                  <li key={index} className="flex items-center gap-1">
+                    <span className="text-terminal-muted" aria-hidden="true">
+                      /
+                    </span>
+                    {crumb.href ? (
+                      <a
+                        href={crumb.href}
+                        className="text-terminal-secondary hover:text-terminal-primary transition-terminal-fast"
+                      >
+                        {crumb.label}
+                      </a>
+                    ) : (
+                      <span className="text-terminal-primary">{crumb.label}</span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            </nav>
+          </div>
+        )}
+      </header>
+
+      {/* Main content area with optional sidebar */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Sidebar (desktop only) */}
+        {showSidebar && sidebarContent && !isMobile && (
+          <aside
+            className={`
+              border-r border-terminal-border bg-terminal-bg-secondary
+              transition-all duration-200 ease-in-out
+              ${sidebarCollapsed ? 'w-12' : 'w-64'}
+            `}
+            aria-label="Sidebar"
+          >
+            {/* Sidebar toggle */}
+            <button
+              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+              className="w-full px-3 py-2 text-terminal-muted hover:text-terminal-primary
+                         border-b border-terminal-border font-mono text-sm
+                         transition-terminal-fast flex items-center justify-between"
+              aria-expanded={!sidebarCollapsed}
+              aria-controls="sidebar-content"
+            >
+              {!sidebarCollapsed && <span>MENU</span>}
+              <span aria-hidden="true">
+                {sidebarCollapsed ? '►' : '◄'}
+              </span>
+            </button>
+
+            {/* Sidebar content */}
+            <div
+              id="sidebar-content"
+              className={`
+                overflow-y-auto
+                ${sidebarCollapsed ? 'hidden' : 'block'}
+              `}
+            >
+              {sidebarContent}
+            </div>
+
+            {/* Keyboard hint for sidebar */}
+            {showKeyboardHints && !sidebarCollapsed && (
+              <div className="absolute bottom-0 left-0 w-64 px-3 py-2 border-t border-terminal-border">
+                <span className="text-terminal-muted text-xs font-mono">
+                  Alt+S to toggle
+                </span>
+              </div>
+            )}
+          </aside>
+        )}
+
+        {/* Main content */}
+        <main
+          className="flex-1 overflow-y-auto p-4 md:p-6"
+          role="main"
+        >
+          {children}
+        </main>
+      </div>
+
+      {/* Footer status bar */}
+      <footer className="border-t border-terminal-border px-4 py-2 md:px-6">
+        <div className="flex items-center justify-between font-mono text-xs md:text-sm">
+          <div className="flex items-center gap-3">
+            <span className="text-terminal-muted uppercase tracking-terminal-wide">
+              STATUS:
+            </span>
+            <StatusIndicator
+              status={systemStatus}
+              label="CONNECTED"
+              size="sm"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 text-terminal-muted">
+            {!isMobile && (
+              <span className="hidden md:inline">
+                DANGUS CLOUD v1.0
+              </span>
+            )}
+            <span aria-hidden="true">│</span>
+            <time dateTime={currentTime.toISOString()}>
+              {formatTimestamp(currentTime)}
+            </time>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export function Breadcrumb({ items = [] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="font-mono text-sm">
+      <ol className="flex items-center gap-1 flex-wrap">
+        <li>
+          <span className="text-terminal-primary">root</span>
+        </li>
+        {items.map((item, index) => (
+          <li key={index} className="flex items-center gap-1">
+            <span className="text-terminal-muted" aria-hidden="true">
+              /
+            </span>
+            {item.href ? (
+              <a
+                href={item.href}
+                className="text-terminal-secondary hover:text-terminal-primary transition-terminal-fast"
+              >
+                {item.label}
+              </a>
+            ) : (
+              <span className="text-terminal-primary">{item.label}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}
+
+export function SidebarMenu({ items = [], onItemClick = () => {} }) {
+  return (
+    <nav className="py-2">
+      {items.map((item, index) => (
+        <button
+          key={index}
+          onClick={() => onItemClick(item)}
+          className={`
+            w-full px-4 py-2 text-left font-mono text-sm
+            transition-terminal-fast flex items-center gap-2
+            ${item.active
+              ? 'text-terminal-primary bg-terminal-bg-elevated'
+              : 'text-terminal-secondary hover:text-terminal-primary hover:bg-terminal-bg-elevated'
+            }
+          `}
+        >
+          <span aria-hidden="true">
+            {item.active ? '►' : ' '}
+          </span>
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </nav>
+  )
+}
+
+export default Layout

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -7,3 +7,4 @@ export {
   ProgressGauge,
   ActivityIndicator
 } from './StatusIndicator'
+export { Layout, Breadcrumb, SidebarMenu } from './Layout'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -408,6 +408,35 @@ body {
 }
 
 /* ========================================
+   Terminal Grid Background Pattern
+   ======================================== */
+@layer utilities {
+  .terminal-grid-bg {
+    background-image:
+      linear-gradient(rgba(51, 255, 51, 0.03) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(51, 255, 51, 0.03) 1px, transparent 1px);
+    background-size: 20px 20px;
+    background-position: -1px -1px;
+  }
+
+  .terminal-grid-bg-subtle {
+    background-image:
+      linear-gradient(rgba(51, 255, 51, 0.015) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(51, 255, 51, 0.015) 1px, transparent 1px);
+    background-size: 16px 16px;
+    background-position: -1px -1px;
+  }
+
+  .terminal-grid-bg-dense {
+    background-image:
+      linear-gradient(rgba(51, 255, 51, 0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(51, 255, 51, 0.04) 1px, transparent 1px);
+    background-size: 8px 8px;
+    background-position: -1px -1px;
+  }
+}
+
+/* ========================================
    Terminal Animations
    ======================================== */
 @keyframes cursor-blink {


### PR DESCRIPTION
## Summary
- Added new Layout component with full terminal UI aesthetic including ASCII logo header, system status indicator, bracket-style navigation, breadcrumb navigation, and footer status bar
- Implemented collapsible sidebar with keyboard navigation support (Alt+S toggle, Alt+1-9 for nav items)
- Added terminal grid background pattern CSS with three variants (default, subtle, dense)
- Updated App.jsx to demonstrate the Layout component integration

## Test plan
- [ ] Verify Layout renders correctly with ASCII logo and system status
- [ ] Test navigation items with bracket styling `[ Dashboard ] - [ Projects ]`
- [ ] Verify breadcrumb navigation displays correctly in format `root / projects / myapp`
- [ ] Test sidebar collapse/expand functionality
- [ ] Verify keyboard navigation (Alt+1-9 for nav, Alt+S for sidebar)
- [ ] Test responsive behavior on mobile (<768px) and desktop viewports
- [ ] Confirm footer shows real-time timestamp and connection status

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)