### PR TITLE
Implement projects CRUD API endpoints

### DIFF
--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -1,0 +1,306 @@
+import { createNamespace, deleteNamespace } from '../services/kubernetes.js';
+
+const NAME_REGEX = /^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$/;
+const NAME_MIN_LENGTH = 1;
+const NAME_MAX_LENGTH = 63;
+
+function validateProjectName(name) {
+  if (!name || typeof name !== 'string') {
+    return { valid: false, error: 'Name is required' };
+  }
+
+  const trimmedName = name.trim();
+
+  if (trimmedName.length < NAME_MIN_LENGTH || trimmedName.length > NAME_MAX_LENGTH) {
+    return { valid: false, error: `Name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters` };
+  }
+
+  if (!NAME_REGEX.test(trimmedName)) {
+    return { valid: false, error: 'Name must be lowercase, start with a letter, and contain only alphanumeric characters and hyphens' };
+  }
+
+  if (trimmedName.includes('--')) {
+    return { valid: false, error: 'Name cannot contain consecutive hyphens' };
+  }
+
+  return { valid: true, name: trimmedName };
+}
+
+function computeNamespace(userHash, projectName) {
+  return `${userHash}-${projectName}`;
+}
+
+export default async function projectRoutes(fastify, options) {
+  const createProjectSchema = {
+    body: {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+      },
+    },
+  };
+
+  const projectParamsSchema = {
+    params: {
+      type: 'object',
+      required: ['id'],
+      properties: {
+        id: { type: 'string', format: 'uuid' },
+      },
+    },
+  };
+
+  /**
+   * GET /projects
+   * List all projects for the authenticated user
+   */
+  fastify.get('/projects', async (request, reply) => {
+    const userId = request.user.id;
+
+    try {
+      const result = await fastify.db.query(
+        `SELECT
+          p.id,
+          p.name,
+          p.created_at,
+          COUNT(s.id)::int AS service_count
+        FROM projects p
+        LEFT JOIN services s ON s.project_id = p.id
+        WHERE p.user_id = $1
+        GROUP BY p.id
+        ORDER BY p.created_at DESC`,
+        [userId]
+      );
+
+      const projects = result.rows.map((row) => ({
+        ...row,
+        namespace: computeNamespace(request.user.hash, row.name),
+      }));
+
+      return { projects };
+    } catch (err) {
+      fastify.log.error(`Failed to list projects: ${err.message}`);
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to list projects',
+      });
+    }
+  });
+
+  /**
+   * POST /projects
+   * Create a new project
+   */
+  fastify.post('/projects', { schema: createProjectSchema }, async (request, reply) => {
+    const userId = request.user.id;
+    const userHash = request.user.hash;
+
+    const validation = validateProjectName(request.body.name);
+    if (!validation.valid) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: validation.error,
+      });
+    }
+
+    const projectName = validation.name;
+    const namespace = computeNamespace(userHash, projectName);
+
+    try {
+      // Check if project name already exists for this user
+      const existing = await fastify.db.query(
+        'SELECT id FROM projects WHERE user_id = $1 AND name = $2',
+        [userId, projectName]
+      );
+
+      if (existing.rows.length > 0) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'A project with this name already exists',
+        });
+      }
+
+      // Create Kubernetes namespace
+      try {
+        await createNamespace(namespace);
+        fastify.log.info(`Created Kubernetes namespace: ${namespace}`);
+      } catch (k8sErr) {
+        fastify.log.error(`Failed to create Kubernetes namespace: ${k8sErr.message}`);
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: 'Failed to create project namespace',
+        });
+      }
+
+      // Insert into database
+      const result = await fastify.db.query(
+        `INSERT INTO projects (user_id, name)
+         VALUES ($1, $2)
+         RETURNING id, name, created_at`,
+        [userId, projectName]
+      );
+
+      const project = result.rows[0];
+
+      fastify.log.info(`Created project: ${projectName} (${project.id}) for user ${userId}`);
+
+      return reply.code(201).send({
+        ...project,
+        namespace,
+        service_count: 0,
+      });
+    } catch (err) {
+      fastify.log.error(`Failed to create project: ${err.message}`);
+
+      // Attempt to clean up the namespace if database insert failed
+      try {
+        await deleteNamespace(namespace);
+      } catch (cleanupErr) {
+        fastify.log.error(`Failed to cleanup namespace after error: ${cleanupErr.message}`);
+      }
+
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to create project',
+      });
+    }
+  });
+
+  /**
+   * GET /projects/:id
+   * Get project details with services
+   */
+  fastify.get('/projects/:id', { schema: projectParamsSchema }, async (request, reply) => {
+    const userId = request.user.id;
+    const projectId = request.params.id;
+
+    try {
+      // Get project
+      const projectResult = await fastify.db.query(
+        'SELECT id, user_id, name, created_at FROM projects WHERE id = $1',
+        [projectId]
+      );
+
+      if (projectResult.rows.length === 0) {
+        return reply.code(404).send({
+          error: 'Not Found',
+          message: 'Project not found',
+        });
+      }
+
+      const project = projectResult.rows[0];
+
+      // Verify ownership
+      if (project.user_id !== userId) {
+        return reply.code(403).send({
+          error: 'Forbidden',
+          message: 'Access denied',
+        });
+      }
+
+      // Get services for this project
+      const servicesResult = await fastify.db.query(
+        `SELECT
+          s.id,
+          s.name,
+          s.repo_url,
+          s.branch,
+          s.dockerfile_path,
+          s.port,
+          s.storage_gb,
+          s.health_check_path,
+          s.created_at,
+          d.status AS current_status,
+          d.created_at AS last_deployment_at
+        FROM services s
+        LEFT JOIN LATERAL (
+          SELECT status, created_at
+          FROM deployments
+          WHERE service_id = s.id
+          ORDER BY created_at DESC
+          LIMIT 1
+        ) d ON true
+        WHERE s.project_id = $1
+        ORDER BY s.created_at DESC`,
+        [projectId]
+      );
+
+      const namespace = computeNamespace(request.user.hash, project.name);
+
+      return {
+        id: project.id,
+        name: project.name,
+        namespace,
+        created_at: project.created_at,
+        services: servicesResult.rows,
+      };
+    } catch (err) {
+      fastify.log.error(`Failed to get project: ${err.message}`);
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to get project',
+      });
+    }
+  });
+
+  /**
+   * DELETE /projects/:id
+   * Delete a project and its Kubernetes namespace
+   */
+  fastify.delete('/projects/:id', { schema: projectParamsSchema }, async (request, reply) => {
+    const userId = request.user.id;
+    const projectId = request.params.id;
+
+    try {
+      // Get project
+      const projectResult = await fastify.db.query(
+        'SELECT id, user_id, name FROM projects WHERE id = $1',
+        [projectId]
+      );
+
+      if (projectResult.rows.length === 0) {
+        return reply.code(404).send({
+          error: 'Not Found',
+          message: 'Project not found',
+        });
+      }
+
+      const project = projectResult.rows[0];
+
+      // Verify ownership
+      if (project.user_id !== userId) {
+        return reply.code(403).send({
+          error: 'Forbidden',
+          message: 'Access denied',
+        });
+      }
+
+      const namespace = computeNamespace(request.user.hash, project.name);
+
+      // Delete Kubernetes namespace (cascades all resources)
+      try {
+        await deleteNamespace(namespace);
+        fastify.log.info(`Deleted Kubernetes namespace: ${namespace}`);
+      } catch (k8sErr) {
+        // Log but continue - namespace might not exist or already deleted
+        if (k8sErr.status !== 404) {
+          fastify.log.warn(`Failed to delete Kubernetes namespace: ${k8sErr.message}`);
+        }
+      }
+
+      // Delete from database (cascades services, env_vars, deployments)
+      await fastify.db.query('DELETE FROM projects WHERE id = $1', [projectId]);
+
+      fastify.log.info(`Deleted project: ${project.name} (${projectId})`);
+
+      return { success: true, message: 'Project deleted successfully' };
+    } catch (err) {
+      fastify.log.error(`Failed to delete project: ${err.message}`);
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to delete project',
+      });
+    }
+  });
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,6 +3,7 @@ import cookie from '@fastify/cookie';
 import databasePlugin from './plugins/database.js';
 import authPlugin from './plugins/auth.js';
 import authRoutes from './routes/auth.js';
+import projectRoutes from './routes/projects.js';
 
 const fastify = Fastify({
   logger: true,
@@ -69,6 +70,9 @@ fastify.register(authPlugin);
 
 // Register auth routes
 fastify.register(authRoutes);
+
+// Register project routes
+fastify.register(projectRoutes);
 
 // Routes that do not require authentication
 const publicRoutes = [

--- a/backend/src/services/kubernetes.js
+++ b/backend/src/services/kubernetes.js
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import https from 'https';
+
+const K8S_API_SERVER = process.env.KUBERNETES_SERVICE_HOST
+  ? `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
+  : 'https://kubernetes.default.svc';
+
+const TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+const CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
+
+function getServiceAccountToken() {
+  try {
+    return fs.readFileSync(TOKEN_PATH, 'utf8').trim();
+  } catch {
+    return process.env.KUBERNETES_TOKEN || null;
+  }
+}
+
+function getCA() {
+  try {
+    return fs.readFileSync(CA_PATH, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function k8sRequest(method, path, body = null) {
+  const token = getServiceAccountToken();
+  if (!token) {
+    throw new Error('Kubernetes authentication not configured');
+  }
+
+  const url = `${K8S_API_SERVER}${path}`;
+  const ca = getCA();
+
+  const options = {
+    method,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+  };
+
+  if (ca) {
+    options.agent = new https.Agent({ ca });
+  } else {
+    options.agent = new https.Agent({ rejectUnauthorized: false });
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage;
+    try {
+      const errorJson = JSON.parse(errorText);
+      errorMessage = errorJson.message || errorText;
+    } catch {
+      errorMessage = errorText;
+    }
+    const error = new Error(`Kubernetes API error: ${errorMessage}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  return response.json();
+}
+
+export async function createNamespace(name) {
+  const namespace = {
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: {
+      name,
+      labels: {
+        'app.kubernetes.io/managed-by': 'dangus-cloud',
+      },
+    },
+  };
+
+  return k8sRequest('POST', '/api/v1/namespaces', namespace);
+}
+
+export async function deleteNamespace(name) {
+  return k8sRequest('DELETE', `/api/v1/namespaces/${name}`);
+}
+
+export async function getNamespace(name) {
+  return k8sRequest('GET', `/api/v1/namespaces/${name}`);
+}
+
+export async function namespaceExists(name) {
+  try {
+    await getNamespace(name);
+    return true;
+  } catch (error) {
+    if (error.status === 404) {
+      return false;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Add Kubernetes service with `createNamespace` and `deleteNamespace` functions for managing project namespaces
- Implement full CRUD API for projects:
  - `GET /projects` - List all projects with service counts, ordered by created_at DESC
  - `POST /projects` - Create project with K8s namespace, validates name format
  - `GET /projects/:id` - Get project details with services and deployment status
  - `DELETE /projects/:id` - Delete project and cleanup K8s namespace
- Add project name validation (lowercase, alphanumeric + hyphens, 1-63 chars)
- Proper error handling with 400, 403, 404, 500 responses

## Test plan
- [ ] Test project creation with valid and invalid names
- [ ] Test listing projects returns correct service counts
- [ ] Test project details include services with deployment status
- [ ] Test ownership verification (403 for other users' projects)
- [ ] Test project deletion cascades K8s resources and database records
- [ ] Test proper error responses for invalid UUIDs

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)