### PR TITLE
Implement replicas support for services

### DIFF
--- a/backend/migrations/006_add_replicas_to_services.sql
+++ b/backend/migrations/006_add_replicas_to_services.sql
@@ -1,0 +1,4 @@
+-- Migration: 006_add_replicas_to_services
+-- Description: Add replicas column to services table for scaling support
+
+ALTER TABLE services ADD COLUMN replicas INTEGER DEFAULT 1 CHECK (replicas >= 1 AND replicas <= 3);

--- a/backend/src/services/manifestGenerator.js
+++ b/backend/src/services/manifestGenerator.js
@@ -105,6 +105,7 @@ export function generateNamespaceManifest(name) {
  * @param {string} options.serviceName - Name of the service
  * @param {string} options.image - Full container image path with tag
  * @param {number} options.port - Container port to expose
+ * @param {number} [options.replicas=1] - Number of replicas (1-3)
  * @param {Array<{name: string, value: string}>} [options.envVars] - Environment variables
  * @param {string} [options.healthCheckPath] - HTTP path for health check probe
  * @param {string} [options.storageMountPath] - Mount path for PVC (default: /data)
@@ -117,6 +118,11 @@ export function generateDeploymentManifest(options) {
     if (!(field in options)) {
       throw new Error(`Missing required option: ${field}`);
     }
+  }
+
+  // Set default replicas if not provided
+  if (!options.replicas) {
+    options.replicas = 1;
   }
 
   // Set default storageMountPath if storageClaimName is provided

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -102,6 +102,7 @@ function AppContent() {
         port: data.port,
         branch: 'main',
         dockerfile_path: 'Dockerfile',
+        replicas: data.replicas || 1,
         storage_gb: data.storage || null,
         health_check_path: data.healthCheckPath || null
       }

--- a/frontend/src/pages/NewServiceForm.jsx
+++ b/frontend/src/pages/NewServiceForm.jsx
@@ -239,7 +239,7 @@ export function NewServiceForm({ projectId, onSubmit, onCancel }) {
               value={formData.replicas}
               onChange={handleInputChange}
               min={1}
-              max={10}
+              max={3}
               step={1}
               unit="replica(s)"
               label="REPLICAS"

--- a/frontend/src/pages/ServiceDetail.jsx
+++ b/frontend/src/pages/ServiceDetail.jsx
@@ -334,6 +334,10 @@ export function ServiceDetail({ serviceId, onBack }) {
               <span className="font-mono text-xs text-terminal-muted uppercase">DOCKERFILE:</span>
               <span className="font-mono text-sm text-terminal-primary">{service.dockerfile_path || 'Dockerfile'}</span>
             </div>
+            <div className="flex items-center justify-between border-b border-terminal-border pb-2">
+              <span className="font-mono text-xs text-terminal-muted uppercase">REPLICAS:</span>
+              <span className="font-mono text-sm text-terminal-primary">{service.replicas || 1}</span>
+            </div>
             {service.storage_gb && (
               <div className="flex items-center justify-between border-b border-terminal-border pb-2">
                 <span className="font-mono text-xs text-terminal-muted uppercase">STORAGE:</span>

--- a/templates/deployment.yaml.tpl
+++ b/templates/deployment.yaml.tpl
@@ -5,6 +5,7 @@
 #   {{serviceName}}      - Name of the service (used for deployment, labels, selectors)
 #   {{image}}            - Full container image path with tag (e.g., registry/app:v1.0.0)
 #   {{port}}             - Container port to expose
+#   {{replicas}}         - Number of pod replicas (1-3, default: 1)
 #   {{envVars}}          - Array of environment variables [{name, value}]
 #   {{healthCheckPath}}  - Optional: HTTP path for health check probe (e.g., /health)
 #   {{storageMountPath}} - Optional: Mount path for PVC (default: /data when enabled)
@@ -27,7 +28,7 @@ metadata:
     app: {{serviceName}}
     managed-by: dangus-cloud
 spec:
-  replicas: 1
+  replicas: {{replicas}}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary
- Add database migration to add replicas column (1-3, default 1)
- Add replicas to backend create/update service schemas and queries
- Update manifest generator to pass replicas to deployment template
- Update deployment template to use dynamic replica count
- Update frontend to send replicas when creating services
- Cap replicas slider at 3 (was 10)
- Display replicas count in ServiceDetail page

## Test plan
- [ ] Create a new service with 2 replicas, verify K8s deployment shows 2 pods
- [ ] Update existing service replicas to 3, verify deployment scales up
- [ ] Verify ServiceDetail page shows correct replica count

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)