### PR TITLE
Real-time build log streaming via WebSocket

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fastify/cookie": "^9.2.0",
     "@fastify/cors": "^9.0.1",
+    "@fastify/websocket": "^8.3.1",
     "@octokit/rest": "^20.0.2",
     "fastify": "^4.24.3",
     "fastify-plugin": "^4.5.1",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
+import websocket from '@fastify/websocket';
 import databasePlugin from './plugins/database.js';
 import authPlugin from './plugins/auth.js';
 import authRoutes from './routes/auth.js';
@@ -67,6 +68,9 @@ fastify.register(cors, {
   origin: FRONTEND_URL,
   credentials: true,
 });
+
+// Register WebSocket plugin for real-time log streaming
+fastify.register(websocket);
 
 // Register database plugin (includes migration runner)
 fastify.register(databasePlugin);

--- a/frontend/src/components/BuildLogViewer.jsx
+++ b/frontend/src/components/BuildLogViewer.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react'
+import { useBuildLogs } from '../hooks/useBuildLogs'
+import TerminalSpinner from './TerminalSpinner'
+
+/**
+ * Real-time build log viewer component
+ * Streams logs via WebSocket and auto-scrolls to bottom
+ */
+export function BuildLogViewer({ deploymentId, enabled = true, onComplete }) {
+  const {
+    logs,
+    status,
+    statusMessage,
+    error,
+    reconnect,
+    isComplete,
+    isError
+  } = useBuildLogs(deploymentId, enabled)
+
+  const logRef = useRef(null)
+  const [autoScroll, setAutoScroll] = useState(true)
+
+  // Auto-scroll to bottom when logs update
+  useEffect(() => {
+    if (autoScroll && logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight
+    }
+  }, [logs, autoScroll])
+
+  // Call onComplete callback when build completes
+  useEffect(() => {
+    if (isComplete && onComplete) {
+      onComplete(status)
+    }
+  }, [isComplete, status, onComplete])
+
+  // Detect manual scrolling to disable auto-scroll
+  const handleScroll = () => {
+    if (!logRef.current) return
+    const { scrollTop, scrollHeight, clientHeight } = logRef.current
+    // If user scrolls up more than 100px from bottom, disable auto-scroll
+    const isNearBottom = scrollHeight - scrollTop - clientHeight < 100
+    setAutoScroll(isNearBottom)
+  }
+
+  const getStatusColor = () => {
+    switch (status) {
+      case 'streaming':
+        return 'text-terminal-cyan'
+      case 'complete':
+        return statusMessage.includes('succeeded') ? 'text-terminal-primary' : 'text-terminal-red'
+      case 'error':
+        return 'text-terminal-red'
+      default:
+        return 'text-terminal-muted'
+    }
+  }
+
+  const getStatusIndicator = () => {
+    switch (status) {
+      case 'connecting':
+      case 'streaming':
+        return <span className="inline-block w-2 h-2 bg-terminal-cyan rounded-full animate-pulse mr-2" />
+      case 'complete':
+        return statusMessage.includes('succeeded')
+          ? <span className="inline-block w-2 h-2 bg-terminal-primary rounded-full mr-2" />
+          : <span className="inline-block w-2 h-2 bg-terminal-red rounded-full mr-2" />
+      case 'error':
+        return <span className="inline-block w-2 h-2 bg-terminal-red rounded-full mr-2" />
+      default:
+        return <span className="inline-block w-2 h-2 bg-terminal-muted rounded-full mr-2" />
+    }
+  }
+
+  return (
+    <div className="border border-terminal-border bg-terminal-bg-secondary">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-terminal-border bg-terminal-bg-elevated">
+        <div className="flex items-center">
+          {getStatusIndicator()}
+          <span className={`font-mono text-xs uppercase ${getStatusColor()}`}>
+            {status === 'streaming' ? 'STREAMING' : status.toUpperCase()}
+          </span>
+          {statusMessage && (
+            <span className="font-mono text-xs text-terminal-muted ml-3">
+              {statusMessage}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {!autoScroll && (
+            <button
+              onClick={() => {
+                setAutoScroll(true)
+                if (logRef.current) {
+                  logRef.current.scrollTop = logRef.current.scrollHeight
+                }
+              }}
+              className="font-mono text-xs text-terminal-muted hover:text-terminal-primary transition-colors"
+            >
+              [SCROLL TO BOTTOM]
+            </button>
+          )}
+          {isError && (
+            <button
+              onClick={reconnect}
+              className="font-mono text-xs text-terminal-secondary hover:text-terminal-primary transition-colors"
+            >
+              [RETRY]
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Log content */}
+      <div
+        ref={logRef}
+        onScroll={handleScroll}
+        className="font-mono text-xs bg-black text-terminal-primary p-4 h-80 overflow-auto"
+        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+      >
+        {error && (
+          <div className="text-terminal-red mb-2">
+            ! Error: {error}
+          </div>
+        )}
+
+        {status === 'connecting' && !logs && (
+          <div className="flex items-center gap-2 text-terminal-muted">
+            <TerminalSpinner />
+            <span>Connecting to build logs...</span>
+          </div>
+        )}
+
+        {logs ? (
+          <pre className="m-0">{logs}</pre>
+        ) : status === 'streaming' && !logs ? (
+          <div className="flex items-center gap-2 text-terminal-muted">
+            <TerminalSpinner />
+            <span>Waiting for logs...</span>
+          </div>
+        ) : null}
+
+        {status === 'streaming' && (
+          <span className="inline-block w-2 h-4 bg-terminal-primary animate-pulse ml-1" />
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default BuildLogViewer

--- a/frontend/src/hooks/useBuildLogs.js
+++ b/frontend/src/hooks/useBuildLogs.js
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
+
+/**
+ * Hook for streaming build logs via WebSocket
+ * @param {string} deploymentId - The deployment ID to stream logs for
+ * @param {boolean} enabled - Whether to enable the WebSocket connection
+ * @returns {{ logs: string, status: string, statusMessage: string, error: string|null }}
+ */
+export function useBuildLogs(deploymentId, enabled = true) {
+  const [logs, setLogs] = useState('')
+  const [status, setStatus] = useState('idle') // idle, connecting, streaming, complete, error
+  const [statusMessage, setStatusMessage] = useState('')
+  const [error, setError] = useState(null)
+  const wsRef = useRef(null)
+  const reconnectTimeoutRef = useRef(null)
+
+  const connect = useCallback(() => {
+    if (!deploymentId || !enabled) return
+
+    // Build WebSocket URL
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const apiUrl = new URL(API_BASE_URL, window.location.origin)
+    const wsUrl = `${wsProtocol}//${apiUrl.host}${apiUrl.pathname}/deployments/${deploymentId}/logs`
+
+    setStatus('connecting')
+    setStatusMessage('Connecting to build logs...')
+    setError(null)
+
+    const ws = new WebSocket(wsUrl)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setStatus('streaming')
+      setStatusMessage('Connected')
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data)
+
+        switch (msg.type) {
+          case 'log':
+            setLogs(prev => prev + msg.data)
+            setStatus('streaming')
+            break
+
+          case 'logs':
+            // Bulk logs (for completed deployments)
+            setLogs(msg.data || '')
+            break
+
+          case 'status':
+            setStatusMessage(msg.message)
+            break
+
+          case 'complete':
+            setStatus('complete')
+            setStatusMessage(`Build ${msg.status === 'live' ? 'succeeded' : msg.status}`)
+            break
+
+          case 'error':
+            setError(msg.message)
+            setStatus('error')
+            break
+
+          default:
+            console.warn('Unknown message type:', msg.type)
+        }
+      } catch (err) {
+        console.error('Failed to parse WebSocket message:', err)
+      }
+    }
+
+    ws.onerror = () => {
+      setError('WebSocket connection error')
+      setStatus('error')
+    }
+
+    ws.onclose = (event) => {
+      if (event.code !== 1000 && event.code !== 1001) {
+        // Abnormal close, might want to reconnect
+        setError(`Connection closed: ${event.reason || 'Unknown reason'}`)
+        setStatus('error')
+      }
+    }
+  }, [deploymentId, enabled])
+
+  // Connect when enabled and deploymentId changes
+  useEffect(() => {
+    if (enabled && deploymentId) {
+      // Reset state for new deployment
+      setLogs('')
+      setError(null)
+      setStatus('idle')
+      setStatusMessage('')
+
+      connect()
+    }
+
+    return () => {
+      // Cleanup on unmount or when dependencies change
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current)
+      }
+      if (wsRef.current) {
+        wsRef.current.close(1000, 'Component unmounting')
+        wsRef.current = null
+      }
+    }
+  }, [deploymentId, enabled, connect])
+
+  // Manual reconnect function
+  const reconnect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close()
+      wsRef.current = null
+    }
+    setLogs('')
+    setError(null)
+    connect()
+  }, [connect])
+
+  return {
+    logs,
+    status,
+    statusMessage,
+    error,
+    reconnect,
+    isConnected: status === 'streaming',
+    isComplete: status === 'complete',
+    isError: status === 'error'
+  }
+}
+
+export default useBuildLogs


### PR DESCRIPTION
## Summary
- Add @fastify/websocket plugin for WebSocket support
- Add streamPodLogs function to stream Kaniko pod logs in real-time
- Add WebSocket endpoint `/deployments/:id/logs` with authentication and ownership verification
- Create useBuildLogs React hook for WebSocket connection management
- Create BuildLogViewer component with auto-scroll and status display
- Integrate build logs into ServiceDetail page with auto-show on deploy trigger

## Test plan
- [ ] Trigger a deployment and verify build logs stream in real-time
- [ ] Verify auto-scroll works and can be manually disabled
- [ ] Verify completed deployments show stored logs immediately
- [ ] Verify WebSocket connection closes gracefully when build completes
- [ ] Verify unauthorized users cannot access logs

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)