### PR TITLE
Add quick restart feature without rebuild

### DIFF
--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -30,6 +30,13 @@ export async function triggerDeploy(id) {
   });
 }
 
+export async function restartService(id, type = 'rolling') {
+  return apiFetch(`/services/${id}/restart`, {
+    method: 'POST',
+    body: JSON.stringify({ type }),
+  });
+}
+
 export async function fetchWebhookSecret(id) {
   return apiFetch(`/services/${id}/webhook-secret`);
 }


### PR DESCRIPTION
## Summary

- Add rolling and hard restart options for services without triggering a full Docker build
- Rolling restart uses kubectl rollout restart (zero-downtime)
- Hard restart deletes pods and lets the deployment recreate them (faster but brief downtime)

## Changes

- **backend/src/services/kubernetes.js**: Add `rolloutRestart` and `deleteServicePods` functions
- **backend/src/routes/services.js**: Add `POST /services/:id/restart` endpoint
- **frontend/src/api/services.js**: Add `restartService` API function
- **frontend/src/pages/ServiceDetail.jsx**: Add restart dropdown button with rolling/hard options

## Test plan

- [ ] Verify rolling restart triggers pod replacement without downtime
- [ ] Verify hard restart immediately deletes and recreates pods
- [ ] Verify restart button shows loading state during operation
- [ ] Verify success/error toast notifications work correctly
- [ ] Verify restart works for services with multiple replicas

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)