### PR TITLE
Add container logs viewer to service detail page

### DIFF
--- a/backend/src/routes/services.js
+++ b/backend/src/routes/services.js
@@ -1,5 +1,5 @@
 import { generateWebhookSecret } from '../services/encryption.js';
-import { deleteDeployment, deleteService, deleteIngress, deletePVC, rolloutRestart, deleteServicePods, getPodMetrics, getDeployment } from '../services/kubernetes.js';
+import { deleteDeployment, deleteService, deleteIngress, deletePVC, rolloutRestart, deleteServicePods, getPodMetrics, getDeployment, getPodsByLabel, getPodLogs, streamPodLogs } from '../services/kubernetes.js';
 import { getLatestCommit, getFileContent } from '../services/github.js';
 import { decrypt, encrypt } from '../services/encryption.js';
 import { runBuildPipeline } from '../services/buildPipeline.js';
@@ -926,7 +926,6 @@ export default async function serviceRoutes(fastify, options) {
   });
 
   /**
-<<<<<<< HEAD
    * POST /services/:id/restart
    * Restart a service without triggering a full rebuild
    */
@@ -945,14 +944,6 @@ export default async function serviceRoutes(fastify, options) {
     const userHash = request.user.hash;
     const serviceId = request.params.id;
     const { type = 'rolling' } = request.body || {};
-=======
-   * POST /services/:id/validate-dockerfile
-   * Validate the Dockerfile for a service before building
-   */
-  fastify.post('/services/:id/validate-dockerfile', { schema: serviceParamsSchema }, async (request, reply) => {
-    const userId = request.user.id;
-    const serviceId = request.params.id;
->>>>>>> 285df69 (Add Dockerfile validation before build)
 
     // Verify ownership
     const ownershipCheck = await verifyServiceOwnership(serviceId, userId);
@@ -964,7 +955,6 @@ export default async function serviceRoutes(fastify, options) {
     }
 
     const { service } = ownershipCheck;
-<<<<<<< HEAD
     const namespace = computeNamespace(userHash, service.project_name);
 
     try {
@@ -986,7 +976,28 @@ export default async function serviceRoutes(fastify, options) {
       return reply.code(500).send({
         error: 'Internal Server Error',
         message: 'Failed to restart service',
-=======
+      });
+    }
+  });
+
+  /**
+   * POST /services/:id/validate-dockerfile
+   * Validate the Dockerfile for a service before building
+   */
+  fastify.post('/services/:id/validate-dockerfile', { schema: serviceParamsSchema }, async (request, reply) => {
+    const userId = request.user.id;
+    const serviceId = request.params.id;
+
+    // Verify ownership
+    const ownershipCheck = await verifyServiceOwnership(serviceId, userId);
+    if (ownershipCheck.error) {
+      return reply.code(ownershipCheck.status).send({
+        error: ownershipCheck.status === 404 ? 'Not Found' : 'Forbidden',
+        message: ownershipCheck.error,
+      });
+    }
+
+    const { service } = ownershipCheck;
 
     // Cannot validate if no repo_url (image-only services)
     if (!service.repo_url) {
@@ -1042,8 +1053,208 @@ export default async function serviceRoutes(fastify, options) {
       return reply.code(500).send({
         error: 'Internal Server Error',
         message: 'Failed to validate Dockerfile',
->>>>>>> 285df69 (Add Dockerfile validation before build)
       });
+    }
+  });
+
+  /**
+   * GET /services/:id/logs
+   * Get container logs for a service
+   */
+  fastify.get('/services/:id/logs', {
+    schema: {
+      ...serviceParamsSchema,
+      querystring: {
+        type: 'object',
+        properties: {
+          tailLines: { type: 'integer', minimum: 1, maximum: 10000, default: 100 },
+          sinceSeconds: { type: 'integer', minimum: 1 },
+          pod: { type: 'string' },
+          container: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const userId = request.user.id;
+    const userHash = request.user.hash;
+    const serviceId = request.params.id;
+    const { tailLines = 100, sinceSeconds, pod, container } = request.query;
+
+    // Verify ownership
+    const ownershipCheck = await verifyServiceOwnership(serviceId, userId);
+    if (ownershipCheck.error) {
+      return reply.code(ownershipCheck.status).send({
+        error: ownershipCheck.status === 404 ? 'Not Found' : 'Forbidden',
+        message: ownershipCheck.error,
+      });
+    }
+
+    const { service } = ownershipCheck;
+    const namespace = computeNamespace(userHash, service.project_name);
+
+    try {
+      // Get all pods for this service
+      const podsResult = await getPodsByLabel(namespace, `app=${service.name}`);
+      const allPods = podsResult.items || [];
+
+      if (allPods.length === 0) {
+        return { pods: [], message: 'No running pods found' };
+      }
+
+      // Filter to specific pod if requested, otherwise get all
+      const targetPods = pod
+        ? allPods.filter(p => p.metadata.name === pod)
+        : allPods;
+
+      if (targetPods.length === 0) {
+        return reply.code(404).send({
+          error: 'Not Found',
+          message: `Pod "${pod}" not found`
+        });
+      }
+
+      // Get logs for each pod
+      const results = await Promise.all(
+        targetPods.map(async (p) => {
+          const podName = p.metadata.name;
+          const containers = p.spec.containers.map(c => c.name);
+          const targetContainer = container || containers[0];
+
+          try {
+            const logs = await getPodLogs(namespace, podName, {
+              tailLines,
+              sinceSeconds,
+              container: targetContainer
+            });
+            return {
+              name: podName,
+              containers,
+              logs,
+              status: p.status.phase
+            };
+          } catch (logErr) {
+            fastify.log.warn(`Failed to get logs for pod ${podName}: ${logErr.message}`);
+            return {
+              name: podName,
+              containers,
+              logs: '',
+              error: logErr.message,
+              status: p.status.phase
+            };
+          }
+        })
+      );
+
+      return { pods: results };
+    } catch (err) {
+      fastify.log.error(`Failed to get container logs: ${err.message}`);
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to get container logs',
+      });
+    }
+  });
+
+  /**
+   * GET /services/:id/logs/stream (WebSocket)
+   * Stream container logs in real-time
+   */
+  fastify.get('/services/:id/logs/stream', {
+    websocket: true,
+    schema: serviceParamsSchema
+  }, async (connection, request) => {
+    const userId = request.user.id;
+    const userHash = request.user.hash;
+    const serviceId = request.params.id;
+    const { pod, container, tailLines = 50 } = request.query;
+
+    // Verify ownership
+    const ownershipCheck = await verifyServiceOwnership(serviceId, userId);
+    if (ownershipCheck.error) {
+      connection.socket.send(JSON.stringify({
+        type: 'error',
+        message: ownershipCheck.error
+      }));
+      connection.socket.close();
+      return;
+    }
+
+    const { service } = ownershipCheck;
+    const namespace = computeNamespace(userHash, service.project_name);
+
+    try {
+      // Get pods if no specific pod requested
+      let targetPod = pod;
+      if (!targetPod) {
+        const podsResult = await getPodsByLabel(namespace, `app=${service.name}`);
+        const allPods = podsResult.items || [];
+        if (allPods.length === 0) {
+          connection.socket.send(JSON.stringify({
+            type: 'error',
+            message: 'No running pods found'
+          }));
+          connection.socket.close();
+          return;
+        }
+        // Use first pod if not specified
+        targetPod = allPods[0].metadata.name;
+
+        // Send pod list to client
+        connection.socket.send(JSON.stringify({
+          type: 'pods',
+          pods: allPods.map(p => ({
+            name: p.metadata.name,
+            containers: p.spec.containers.map(c => c.name),
+            status: p.status.phase
+          }))
+        }));
+      }
+
+      // Start streaming logs
+      const logStream = streamPodLogs(namespace, targetPod, {
+        container,
+        tailLines: parseInt(tailLines, 10)
+      });
+
+      connection.socket.send(JSON.stringify({
+        type: 'connected',
+        pod: targetPod,
+        container: container || 'default'
+      }));
+
+      logStream.on('data', (chunk) => {
+        connection.socket.send(JSON.stringify({
+          type: 'log',
+          data: chunk
+        }));
+      });
+
+      logStream.on('error', (err) => {
+        connection.socket.send(JSON.stringify({
+          type: 'error',
+          message: err.message
+        }));
+      });
+
+      logStream.on('end', () => {
+        connection.socket.send(JSON.stringify({
+          type: 'end',
+          message: 'Log stream ended'
+        }));
+      });
+
+      // Cleanup on socket close
+      connection.socket.on('close', () => {
+        logStream.destroy();
+      });
+
+    } catch (err) {
+      fastify.log.error(`Failed to stream container logs: ${err.message}`);
+      connection.socket.send(JSON.stringify({
+        type: 'error',
+        message: 'Failed to stream logs'
+      }));
+      connection.socket.close();
     }
   });
 

--- a/backend/src/services/kubernetes.js
+++ b/backend/src/services/kubernetes.js
@@ -236,9 +236,12 @@ export async function getPodMetrics(namespace, labelSelector) {
   }));
 }
 
-export async function getPodLogs(namespace, podName, container = null) {
-  const containerParam = container ? `&container=${container}` : '';
-  const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log?timestamps=true${containerParam}`;
+export async function getPodLogs(namespace, podName, options = {}) {
+  const { container = null, tailLines = 100, sinceSeconds = null } = options;
+  let path = `/api/v1/namespaces/${namespace}/pods/${podName}/log?timestamps=true`;
+  if (container) path += `&container=${container}`;
+  if (tailLines) path += `&tailLines=${tailLines}`;
+  if (sinceSeconds) path += `&sinceSeconds=${sinceSeconds}`;
   const token = getServiceAccountToken();
   if (!token) {
     throw new Error('Kubernetes authentication not configured');
@@ -286,9 +289,11 @@ export async function getPodLogs(namespace, podName, container = null) {
  * Stream pod logs in real-time using follow mode
  * Returns an EventEmitter-like object that emits 'data', 'error', and 'end' events
  */
-export function streamPodLogs(namespace, podName, container = null) {
-  const containerParam = container ? `&container=${container}` : '';
-  const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log?follow=true&timestamps=true${containerParam}`;
+export function streamPodLogs(namespace, podName, options = {}) {
+  const { container = null, tailLines = 100 } = options;
+  let path = `/api/v1/namespaces/${namespace}/pods/${podName}/log?follow=true&timestamps=true`;
+  if (container) path += `&container=${container}`;
+  if (tailLines) path += `&tailLines=${tailLines}`;
   const token = getServiceAccountToken();
 
   if (!token) {

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -68,3 +68,25 @@ export async function validateDockerfile(id) {
     method: 'POST'
   });
 }
+
+/**
+ * Fetch container logs for a service
+ * @param {string} id - Service ID
+ * @param {object} options - Query options
+ * @param {number} options.tailLines - Number of lines to fetch (default 100)
+ * @param {number} options.sinceSeconds - Fetch logs from last N seconds
+ * @param {string} options.pod - Specific pod name
+ * @param {string} options.container - Specific container name
+ * @returns {Promise<{pods: Array}>}
+ */
+export async function fetchServiceLogs(id, options = {}) {
+  const params = new URLSearchParams();
+  if (options.tailLines) params.append('tailLines', options.tailLines);
+  if (options.sinceSeconds) params.append('sinceSeconds', options.sinceSeconds);
+  if (options.pod) params.append('pod', options.pod);
+  if (options.container) params.append('container', options.container);
+
+  const queryString = params.toString();
+  const url = `/services/${id}/logs${queryString ? `?${queryString}` : ''}`;
+  return apiFetch(url);
+}

--- a/frontend/src/components/LogViewer.jsx
+++ b/frontend/src/components/LogViewer.jsx
@@ -1,0 +1,363 @@
+import { useEffect, useRef, useState, useMemo } from 'react'
+import { useContainerLogs } from '../hooks/useContainerLogs'
+import { fetchServiceLogs } from '../api/services'
+import TerminalSpinner from './TerminalSpinner'
+import TerminalButton from './TerminalButton'
+import TerminalInput from './TerminalInput'
+
+/**
+ * Container logs viewer component
+ * Supports real-time streaming and historical log viewing
+ */
+export function LogViewer({ serviceId, enabled = true }) {
+  const [mode, setMode] = useState('historical') // 'historical' or 'streaming'
+  const [historicalLogs, setHistoricalLogs] = useState('')
+  const [historicalPods, setHistoricalPods] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [fetchError, setFetchError] = useState(null)
+  const [filter, setFilter] = useState('')
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [selectedPodName, setSelectedPodName] = useState('')
+  const [tailLines, setTailLines] = useState(200)
+
+  const logRef = useRef(null)
+
+  const {
+    logs: streamLogs,
+    pods: streamPods,
+    selectedPod,
+    status,
+    statusMessage,
+    error: streamError,
+    connect,
+    disconnect,
+    reconnect,
+    changePod,
+    clearLogs,
+    isConnected,
+    isDisconnected,
+    isError
+  } = useContainerLogs(serviceId, { tailLines: 100 }, mode === 'streaming' && enabled)
+
+  // Fetch historical logs
+  const fetchLogs = async (podName = selectedPodName) => {
+    setLoading(true)
+    setFetchError(null)
+    try {
+      const result = await fetchServiceLogs(serviceId, {
+        tailLines,
+        pod: podName || undefined
+      })
+      setHistoricalPods(result.pods || [])
+      if (result.pods && result.pods.length > 0) {
+        const targetPod = podName
+          ? result.pods.find(p => p.name === podName)
+          : result.pods[0]
+        if (targetPod) {
+          setHistoricalLogs(targetPod.logs || '')
+          if (!selectedPodName) {
+            setSelectedPodName(targetPod.name)
+          }
+        }
+      } else {
+        setHistoricalLogs('')
+      }
+    } catch (err) {
+      setFetchError(err.message || 'Failed to fetch logs')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Initial fetch when component mounts
+  useEffect(() => {
+    if (enabled && mode === 'historical') {
+      fetchLogs()
+    }
+  }, [serviceId, enabled, mode])
+
+  // Auto-scroll to bottom when logs update
+  useEffect(() => {
+    if (autoScroll && logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight
+    }
+  }, [streamLogs, historicalLogs, autoScroll])
+
+  // Detect manual scrolling
+  const handleScroll = () => {
+    if (!logRef.current) return
+    const { scrollTop, scrollHeight, clientHeight } = logRef.current
+    const isNearBottom = scrollHeight - scrollTop - clientHeight < 100
+    setAutoScroll(isNearBottom)
+  }
+
+  // Get active logs and pods based on mode
+  const activeLogs = mode === 'streaming' ? streamLogs : historicalLogs
+  const activePods = mode === 'streaming' ? streamPods : historicalPods
+  const activeError = mode === 'streaming' ? streamError : fetchError
+
+  // Filter logs
+  const filteredLogs = useMemo(() => {
+    if (!filter.trim()) return activeLogs
+    const lines = activeLogs.split('\n')
+    return lines
+      .filter(line => line.toLowerCase().includes(filter.toLowerCase()))
+      .join('\n')
+  }, [activeLogs, filter])
+
+  // Handle pod change
+  const handlePodChange = (e) => {
+    const podName = e.target.value
+    setSelectedPodName(podName)
+    if (mode === 'streaming') {
+      changePod(podName)
+    } else {
+      fetchLogs(podName)
+    }
+  }
+
+  // Handle mode toggle
+  const handleModeToggle = () => {
+    if (mode === 'historical') {
+      setMode('streaming')
+    } else {
+      disconnect()
+      setMode('historical')
+      fetchLogs(selectedPodName)
+    }
+  }
+
+  // Download logs
+  const downloadLogs = () => {
+    const blob = new Blob([activeLogs], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `logs-${serviceId}-${selectedPodName || 'all'}-${new Date().toISOString().slice(0, 19)}.txt`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  const getStatusColor = () => {
+    if (mode === 'historical') return 'text-terminal-secondary'
+    switch (status) {
+      case 'streaming':
+        return 'text-terminal-cyan'
+      case 'error':
+        return 'text-terminal-red'
+      default:
+        return 'text-terminal-muted'
+    }
+  }
+
+  const getStatusIndicator = () => {
+    if (mode === 'historical') {
+      return loading
+        ? <TerminalSpinner className="mr-2" />
+        : <span className="inline-block w-2 h-2 bg-terminal-secondary rounded-full mr-2" />
+    }
+    switch (status) {
+      case 'connecting':
+      case 'streaming':
+        return <span className="inline-block w-2 h-2 bg-terminal-cyan rounded-full animate-pulse mr-2" />
+      case 'error':
+        return <span className="inline-block w-2 h-2 bg-terminal-red rounded-full mr-2" />
+      default:
+        return <span className="inline-block w-2 h-2 bg-terminal-muted rounded-full mr-2" />
+    }
+  }
+
+  const getStatusText = () => {
+    if (mode === 'historical') {
+      return loading ? 'LOADING' : 'HISTORICAL'
+    }
+    return status === 'streaming' ? 'STREAMING' : status.toUpperCase()
+  }
+
+  return (
+    <div className="border border-terminal-border bg-terminal-bg-secondary">
+      {/* Header */}
+      <div className="flex flex-col gap-2 px-4 py-3 border-b border-terminal-border bg-terminal-bg-elevated">
+        {/* Top row: Status and controls */}
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <div className="flex items-center">
+            {getStatusIndicator()}
+            <span className={`font-mono text-xs uppercase ${getStatusColor()}`}>
+              {getStatusText()}
+            </span>
+            {statusMessage && mode === 'streaming' && (
+              <span className="font-mono text-xs text-terminal-muted ml-3">
+                {statusMessage}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            {!autoScroll && (
+              <button
+                onClick={() => {
+                  setAutoScroll(true)
+                  if (logRef.current) {
+                    logRef.current.scrollTop = logRef.current.scrollHeight
+                  }
+                }}
+                className="font-mono text-xs text-terminal-muted hover:text-terminal-primary transition-colors"
+              >
+                [SCROLL]
+              </button>
+            )}
+            {mode === 'historical' && (
+              <button
+                onClick={() => fetchLogs(selectedPodName)}
+                disabled={loading}
+                className="font-mono text-xs text-terminal-secondary hover:text-terminal-primary transition-colors disabled:opacity-50"
+              >
+                [REFRESH]
+              </button>
+            )}
+            {mode === 'streaming' && isError && (
+              <button
+                onClick={reconnect}
+                className="font-mono text-xs text-terminal-secondary hover:text-terminal-primary transition-colors"
+              >
+                [RETRY]
+              </button>
+            )}
+            {activeLogs && (
+              <button
+                onClick={downloadLogs}
+                className="font-mono text-xs text-terminal-muted hover:text-terminal-primary transition-colors"
+              >
+                [DOWNLOAD]
+              </button>
+            )}
+            {mode === 'streaming' && (
+              <button
+                onClick={clearLogs}
+                className="font-mono text-xs text-terminal-muted hover:text-terminal-primary transition-colors"
+              >
+                [CLEAR]
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Bottom row: Pod selector, filter, mode toggle */}
+        <div className="flex items-center gap-3 flex-wrap">
+          {/* Pod selector */}
+          {activePods.length > 0 && (
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs text-terminal-muted">POD:</span>
+              <select
+                value={selectedPodName || (mode === 'streaming' ? selectedPod : '')}
+                onChange={handlePodChange}
+                className="bg-terminal-bg-secondary text-terminal-primary font-mono text-xs border border-terminal-border px-2 py-1 focus:outline-none focus:border-terminal-primary"
+              >
+                {activePods.map(pod => (
+                  <option key={pod.name} value={pod.name}>
+                    {pod.name} ({pod.status || 'Unknown'})
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Filter input */}
+          <div className="flex items-center gap-2 flex-1 min-w-[150px] max-w-xs">
+            <span className="font-mono text-xs text-terminal-muted">FILTER:</span>
+            <TerminalInput
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Search logs..."
+              className="flex-1 text-xs py-1"
+            />
+          </div>
+
+          {/* Mode toggle */}
+          <TerminalButton
+            variant={mode === 'streaming' ? 'primary' : 'secondary'}
+            onClick={handleModeToggle}
+            disabled={loading}
+            className="text-xs py-1"
+          >
+            {mode === 'streaming' ? '[ STOP STREAM ]' : '[ STREAM ]'}
+          </TerminalButton>
+        </div>
+      </div>
+
+      {/* Log content */}
+      <div
+        ref={logRef}
+        onScroll={handleScroll}
+        className="font-mono text-xs bg-black text-terminal-primary p-4 h-96 overflow-auto"
+        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+      >
+        {activeError && (
+          <div className="text-terminal-red mb-2">
+            ! Error: {activeError}
+          </div>
+        )}
+
+        {loading && !filteredLogs && (
+          <div className="flex items-center gap-2 text-terminal-muted">
+            <TerminalSpinner />
+            <span>Loading logs...</span>
+          </div>
+        )}
+
+        {mode === 'streaming' && status === 'connecting' && !filteredLogs && (
+          <div className="flex items-center gap-2 text-terminal-muted">
+            <TerminalSpinner />
+            <span>Connecting to log stream...</span>
+          </div>
+        )}
+
+        {!loading && !filteredLogs && !activeError && (
+          <div className="text-terminal-muted">
+            {activePods.length === 0
+              ? 'No running pods found. Deploy the service to view logs.'
+              : 'No logs available.'}
+          </div>
+        )}
+
+        {filteredLogs && (
+          <pre className="m-0">{filteredLogs}</pre>
+        )}
+
+        {mode === 'streaming' && isConnected && (
+          <span className="inline-block w-2 h-4 bg-terminal-primary animate-pulse ml-1" />
+        )}
+      </div>
+
+      {/* Footer with line count */}
+      <div className="px-4 py-2 border-t border-terminal-border bg-terminal-bg-elevated">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-xs text-terminal-muted">
+            {filteredLogs ? filteredLogs.split('\n').length : 0} lines
+            {filter && ` (filtered from ${activeLogs.split('\n').length})`}
+          </span>
+          {mode === 'historical' && (
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs text-terminal-muted">TAIL:</span>
+              <select
+                value={tailLines}
+                onChange={(e) => {
+                  setTailLines(parseInt(e.target.value, 10))
+                }}
+                className="bg-terminal-bg-secondary text-terminal-primary font-mono text-xs border border-terminal-border px-2 py-1 focus:outline-none focus:border-terminal-primary"
+              >
+                <option value={100}>100</option>
+                <option value={200}>200</option>
+                <option value={500}>500</option>
+                <option value={1000}>1000</option>
+              </select>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default LogViewer

--- a/frontend/src/hooks/useContainerLogs.js
+++ b/frontend/src/hooks/useContainerLogs.js
@@ -1,0 +1,176 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
+
+/**
+ * Hook for streaming container logs via WebSocket
+ * @param {string} serviceId - The service ID to stream logs for
+ * @param {object} options - Options for the log stream
+ * @param {string} options.pod - Specific pod name (optional)
+ * @param {string} options.container - Specific container name (optional)
+ * @param {number} options.tailLines - Number of lines to tail (default 100)
+ * @param {boolean} enabled - Whether to enable the WebSocket connection
+ * @returns {{ logs: string, pods: Array, selectedPod: string, status: string, error: string|null }}
+ */
+export function useContainerLogs(serviceId, options = {}, enabled = true) {
+  const [logs, setLogs] = useState('')
+  const [pods, setPods] = useState([])
+  const [selectedPod, setSelectedPod] = useState(options.pod || null)
+  const [selectedContainer, setSelectedContainer] = useState(options.container || null)
+  const [status, setStatus] = useState('idle') // idle, connecting, streaming, disconnected, error
+  const [statusMessage, setStatusMessage] = useState('')
+  const [error, setError] = useState(null)
+  const wsRef = useRef(null)
+
+  const connect = useCallback(() => {
+    if (!serviceId || !enabled) return
+
+    // Build WebSocket URL with query params
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const apiUrl = new URL(API_BASE_URL, window.location.origin)
+
+    const params = new URLSearchParams()
+    if (selectedPod) params.append('pod', selectedPod)
+    if (selectedContainer) params.append('container', selectedContainer)
+    if (options.tailLines) params.append('tailLines', options.tailLines)
+
+    const queryString = params.toString()
+    const wsUrl = `${wsProtocol}//${apiUrl.host}${apiUrl.pathname}/services/${serviceId}/logs/stream${queryString ? `?${queryString}` : ''}`
+
+    setStatus('connecting')
+    setStatusMessage('Connecting to container logs...')
+    setError(null)
+
+    const ws = new WebSocket(wsUrl)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setStatus('streaming')
+      setStatusMessage('Connected')
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data)
+
+        switch (msg.type) {
+          case 'connected':
+            setStatus('streaming')
+            setStatusMessage(`Streaming logs from ${msg.pod}`)
+            if (!selectedPod) setSelectedPod(msg.pod)
+            break
+
+          case 'pods':
+            setPods(msg.pods || [])
+            break
+
+          case 'log':
+            setLogs(prev => prev + msg.data)
+            break
+
+          case 'error':
+            setError(msg.message)
+            setStatus('error')
+            break
+
+          case 'end':
+            setStatusMessage('Log stream ended')
+            setStatus('disconnected')
+            break
+
+          default:
+            console.warn('Unknown message type:', msg.type)
+        }
+      } catch (err) {
+        console.error('Failed to parse WebSocket message:', err)
+      }
+    }
+
+    ws.onerror = () => {
+      setError('WebSocket connection error')
+      setStatus('error')
+    }
+
+    ws.onclose = (event) => {
+      if (event.code !== 1000 && event.code !== 1001 && status === 'streaming') {
+        setError(`Connection closed unexpectedly`)
+        setStatus('error')
+      } else if (status !== 'error') {
+        setStatus('disconnected')
+      }
+    }
+  }, [serviceId, selectedPod, selectedContainer, options.tailLines, enabled, status])
+
+  // Disconnect function
+  const disconnect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close(1000, 'User disconnected')
+      wsRef.current = null
+    }
+    setStatus('disconnected')
+    setStatusMessage('Disconnected')
+  }, [])
+
+  // Reconnect function
+  const reconnect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close()
+      wsRef.current = null
+    }
+    setLogs('')
+    setError(null)
+    connect()
+  }, [connect])
+
+  // Change pod function
+  const changePod = useCallback((podName) => {
+    if (wsRef.current) {
+      wsRef.current.close()
+      wsRef.current = null
+    }
+    setSelectedPod(podName)
+    setLogs('')
+    setError(null)
+  }, [])
+
+  // Clear logs function
+  const clearLogs = useCallback(() => {
+    setLogs('')
+  }, [])
+
+  // Connect when enabled and serviceId changes, or when pod changes
+  useEffect(() => {
+    if (enabled && serviceId && status !== 'streaming') {
+      connect()
+    }
+
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close(1000, 'Component unmounting')
+        wsRef.current = null
+      }
+    }
+  }, [serviceId, enabled, selectedPod])
+
+  return {
+    logs,
+    pods,
+    selectedPod,
+    selectedContainer,
+    status,
+    statusMessage,
+    error,
+    connect,
+    disconnect,
+    reconnect,
+    changePod,
+    clearLogs,
+    setSelectedPod,
+    setSelectedContainer,
+    isConnected: status === 'streaming',
+    isDisconnected: status === 'disconnected' || status === 'idle',
+    isError: status === 'error'
+  }
+}
+
+export default useContainerLogs

--- a/frontend/src/pages/ServiceDetail.jsx
+++ b/frontend/src/pages/ServiceDetail.jsx
@@ -8,6 +8,7 @@ import TerminalSpinner from '../components/TerminalSpinner'
 import { useToast } from '../components/Toast'
 import { BuildLogViewer } from '../components/BuildLogViewer'
 import { ResourceMetrics } from '../components/ResourceMetrics'
+import { LogViewer } from '../components/LogViewer'
 import { fetchService, triggerDeploy, fetchWebhookSecret, restartService, fetchServiceMetrics, validateDockerfile } from '../api/services'
 import { fetchEnvVars, createEnvVar, updateEnvVar, deleteEnvVar, revealEnvVar } from '../api/envVars'
 import { fetchDeployments } from '../api/deployments'
@@ -27,6 +28,7 @@ export function ServiceDetail({ serviceId, onBack }) {
   const [historyCollapsed, setHistoryCollapsed] = useState(false)
   const [buildLogsCollapsed, setBuildLogsCollapsed] = useState(false)
   const [showBuildLogs, setShowBuildLogs] = useState(false)
+  const [containerLogsCollapsed, setContainerLogsCollapsed] = useState(false)
 
   const [copied, setCopied] = useState(null)
   const [revealedSecrets, setRevealedSecrets] = useState({})
@@ -678,6 +680,23 @@ export function ServiceDetail({ serviceId, onBack }) {
             serviceId={serviceId}
             fetchMetrics={fetchServiceMetrics}
             refreshInterval={5000}
+          />
+        </div>
+      )}
+
+      {/* Container Logs Section */}
+      <AsciiSectionDivider
+        title="CONTAINER LOGS"
+        collapsed={containerLogsCollapsed}
+        onToggle={() => setContainerLogsCollapsed(!containerLogsCollapsed)}
+        color="green"
+      />
+
+      {!containerLogsCollapsed && (
+        <div className="mt-4">
+          <LogViewer
+            serviceId={serviceId}
+            enabled={!containerLogsCollapsed}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add REST endpoint `GET /services/:id/logs` for fetching container logs with pagination (tailLines, sinceSeconds)
- Add WebSocket endpoint `GET /services/:id/logs/stream` for real-time log streaming
- Enhance `getPodLogs` and `streamPodLogs` Kubernetes functions with tailLines/sinceSeconds parameters
- Create `LogViewer` component with pod selection, log filtering, and download functionality
- Create `useContainerLogs` hook for managing WebSocket log streaming
- Integrate container logs viewer into the ServiceDetail page

## Test plan
- [ ] Navigate to a deployed service's detail page
- [ ] Verify the Container Logs section appears
- [ ] Test historical log viewing (loads last 200 lines by default)
- [ ] Test pod selection dropdown for multi-replica services
- [ ] Test log filtering with the search box
- [ ] Test real-time streaming by clicking STREAM button
- [ ] Test download functionality
- [ ] Verify logs are correctly displayed with timestamps
- [ ] Test error handling when no pods are running

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)