### PR TITLE
Add health check status monitoring

### DIFF
--- a/backend/migrations/008_create_health_checks.sql
+++ b/backend/migrations/008_create_health_checks.sql
@@ -1,0 +1,22 @@
+-- Health check history table
+CREATE TABLE health_checks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_id UUID NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+  status VARCHAR(20) NOT NULL, -- healthy, unhealthy
+  status_code INTEGER,
+  response_time_ms INTEGER,
+  error TEXT,
+  checked_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for efficient queries by service and time
+CREATE INDEX idx_health_checks_service ON health_checks(service_id, checked_at DESC);
+
+-- Auto-cleanup old records (older than 7 days)
+CREATE OR REPLACE FUNCTION cleanup_old_health_checks()
+RETURNS void AS $$
+BEGIN
+  DELETE FROM health_checks
+  WHERE checked_at < NOW() - INTERVAL '7 days';
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/src/services/healthChecker.js
+++ b/backend/src/services/healthChecker.js
@@ -1,0 +1,187 @@
+import logger from './logger.js';
+
+const BASE_DOMAIN = process.env.BASE_DOMAIN || '192.168.1.124.nip.io';
+const HEALTH_CHECK_INTERVAL = parseInt(process.env.HEALTH_CHECK_INTERVAL, 10) || 60000; // 1 minute default
+const HEALTH_CHECK_TIMEOUT = parseInt(process.env.HEALTH_CHECK_TIMEOUT, 10) || 5000; // 5 second timeout
+
+/**
+ * Compute the subdomain for a service
+ */
+function computeSubdomain(userHash, serviceName) {
+  return `${userHash}-${serviceName}`;
+}
+
+/**
+ * Perform an active health check against a service's health endpoint
+ * @param {string} subdomain - The service subdomain
+ * @param {string} healthPath - The health check path (e.g., "/health")
+ * @param {number} port - The service port (used for internal routing context)
+ * @returns {Promise<object>} Health check result
+ */
+export async function performHealthCheck(subdomain, healthPath, port) {
+  const url = `http://${subdomain}.${BASE_DOMAIN}${healthPath}`;
+  const start = Date.now();
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT);
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'DangusCloud-HealthCheck/1.0'
+      }
+    });
+
+    clearTimeout(timeout);
+
+    return {
+      status: response.ok ? 'healthy' : 'unhealthy',
+      statusCode: response.status,
+      responseTimeMs: Date.now() - start,
+      lastCheck: new Date().toISOString()
+    };
+  } catch (error) {
+    return {
+      status: 'unhealthy',
+      error: error.name === 'AbortError' ? 'Timeout' : error.message,
+      responseTimeMs: Date.now() - start,
+      lastCheck: new Date().toISOString()
+    };
+  }
+}
+
+/**
+ * Get health check history for a service
+ * @param {object} db - Database connection
+ * @param {string} serviceId - Service UUID
+ * @param {number} limit - Number of records to return
+ * @returns {Promise<Array>} Health check history
+ */
+export async function getHealthHistory(db, serviceId, limit = 20) {
+  const result = await db.query(
+    `SELECT status, status_code, response_time_ms, error, checked_at
+     FROM health_checks
+     WHERE service_id = $1
+     ORDER BY checked_at DESC
+     LIMIT $2`,
+    [serviceId, limit]
+  );
+
+  return result.rows.map(row => ({
+    status: row.status,
+    statusCode: row.status_code,
+    responseTimeMs: row.response_time_ms,
+    error: row.error,
+    timestamp: row.checked_at
+  }));
+}
+
+/**
+ * Store a health check result
+ * @param {object} db - Database connection
+ * @param {string} serviceId - Service UUID
+ * @param {object} result - Health check result
+ */
+async function storeHealthCheck(db, serviceId, result) {
+  await db.query(
+    `INSERT INTO health_checks (service_id, status, status_code, response_time_ms, error)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [serviceId, result.status, result.statusCode || null, result.responseTimeMs, result.error || null]
+  );
+}
+
+/**
+ * Clean up old health check records
+ * @param {object} db - Database connection
+ */
+async function cleanupOldRecords(db) {
+  try {
+    const result = await db.query(
+      `DELETE FROM health_checks WHERE checked_at < NOW() - INTERVAL '7 days'`
+    );
+    if (result.rowCount > 0) {
+      logger.info(`Cleaned up ${result.rowCount} old health check records`);
+    }
+  } catch (err) {
+    logger.error(`Failed to cleanup old health checks: ${err.message}`);
+  }
+}
+
+/**
+ * Run health checks for all services with health check paths configured
+ * @param {object} db - Database connection
+ */
+async function runHealthChecks(db) {
+  try {
+    // Get all services with health checks configured that have been deployed
+    const result = await db.query(
+      `SELECT s.id, s.name, s.port, s.health_check_path, u.hash as user_hash
+       FROM services s
+       JOIN projects p ON s.project_id = p.id
+       JOIN users u ON p.user_id = u.id
+       WHERE s.health_check_path IS NOT NULL
+       AND EXISTS (
+         SELECT 1 FROM deployments d
+         WHERE d.service_id = s.id
+         AND d.status = 'live'
+       )`
+    );
+
+    const services = result.rows;
+
+    if (services.length === 0) {
+      return;
+    }
+
+    logger.debug(`Running health checks for ${services.length} services`);
+
+    for (const service of services) {
+      try {
+        const subdomain = computeSubdomain(service.user_hash, service.name);
+        const healthResult = await performHealthCheck(
+          subdomain,
+          service.health_check_path,
+          service.port
+        );
+
+        await storeHealthCheck(db, service.id, healthResult);
+
+        if (healthResult.status === 'unhealthy') {
+          logger.warn(`Health check failed for ${service.name}: ${healthResult.error || `Status ${healthResult.statusCode}`}`);
+        }
+      } catch (err) {
+        logger.error(`Error checking health for service ${service.name}: ${err.message}`);
+      }
+    }
+  } catch (err) {
+    logger.error(`Failed to run health checks: ${err.message}`);
+  }
+}
+
+/**
+ * Start the background health checker
+ * @param {object} db - Database connection
+ * @returns {object} Control object with stop method
+ */
+export function startHealthChecker(db) {
+  logger.info(`Starting health checker with ${HEALTH_CHECK_INTERVAL}ms interval`);
+
+  // Run initial health checks after a short delay
+  const initialTimeout = setTimeout(() => runHealthChecks(db), 5000);
+
+  // Set up periodic health checks
+  const checkInterval = setInterval(() => runHealthChecks(db), HEALTH_CHECK_INTERVAL);
+
+  // Clean up old records once per hour
+  const cleanupInterval = setInterval(() => cleanupOldRecords(db), 3600000);
+
+  return {
+    stop() {
+      clearTimeout(initialTimeout);
+      clearInterval(checkInterval);
+      clearInterval(cleanupInterval);
+      logger.info('Health checker stopped');
+    }
+  };
+}

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -90,3 +90,12 @@ export async function fetchServiceLogs(id, options = {}) {
   const url = `/services/${id}/logs${queryString ? `?${queryString}` : ''}`;
   return apiFetch(url);
 }
+
+/**
+ * Fetch health check status for a service
+ * @param {string} id - Service ID
+ * @returns {Promise<{configured: boolean, path?: string, status?: string, pods?: Array, activeCheck?: object, history?: Array, events?: Array}>}
+ */
+export async function fetchServiceHealth(id) {
+  return apiFetch(`/services/${id}/health`);
+}

--- a/frontend/src/components/HealthStatus.jsx
+++ b/frontend/src/components/HealthStatus.jsx
@@ -1,0 +1,283 @@
+import { useState, useEffect } from 'react'
+import TerminalSpinner from './TerminalSpinner'
+import { AsciiBox } from './AsciiBox'
+import { StatusIndicator } from './StatusIndicator'
+
+function ResponseTimeChart({ history }) {
+  if (!history || history.length === 0) {
+    return (
+      <div className="text-center py-2 text-terminal-muted text-xs font-mono">
+        No response time data available
+      </div>
+    )
+  }
+
+  // Get last 10 entries for the chart
+  const chartData = history.slice(0, 10).reverse()
+  const maxTime = Math.max(...chartData.map(h => h.responseTimeMs || 0), 100)
+  const chartHeight = 40
+
+  return (
+    <div className="font-mono">
+      <div className="text-xs text-terminal-muted uppercase mb-2">Response Time (last 10 checks)</div>
+      <div className="flex items-end gap-1 h-10 border-l border-b border-terminal-border pl-1">
+        {chartData.map((entry, idx) => {
+          const height = entry.responseTimeMs
+            ? Math.max((entry.responseTimeMs / maxTime) * chartHeight, 2)
+            : 0
+          const isHealthy = entry.status === 'healthy'
+
+          return (
+            <div
+              key={idx}
+              className={`w-4 transition-all ${isHealthy ? 'bg-terminal-primary' : 'bg-terminal-red'}`}
+              style={{ height: `${height}px` }}
+              title={`${entry.responseTimeMs || 0}ms - ${entry.status}`}
+            />
+          )
+        })}
+      </div>
+      <div className="flex justify-between text-xs text-terminal-muted mt-1">
+        <span>0ms</span>
+        <span>{maxTime}ms</span>
+      </div>
+    </div>
+  )
+}
+
+function PodHealthRow({ pod, isLast }) {
+  const isReady = pod.ready
+  const statusColor = isReady ? 'text-terminal-primary' : 'text-terminal-red'
+  const indicator = isReady ? '\u25CF' : '\u25CB'
+
+  return (
+    <div className={`py-2 ${!isLast ? 'border-b border-terminal-border' : ''}`}>
+      <div className="flex items-center gap-2 text-sm">
+        <span className={statusColor}>{indicator}</span>
+        <span className="text-terminal-cyan truncate max-w-[200px]">{pod.name}</span>
+        <span className={`text-xs ${isReady ? 'text-terminal-primary' : 'text-terminal-red'}`}>
+          {isReady ? 'Ready' : 'Not Ready'}
+        </span>
+      </div>
+      <div className="flex gap-4 mt-1 text-xs text-terminal-muted ml-4">
+        <span>Phase: {pod.phase || 'Unknown'}</span>
+        <span>Restarts: {pod.restartCount}</span>
+      </div>
+      <div className="flex gap-4 mt-1 text-xs ml-4">
+        <span className={pod.readiness?.status === 'passing' ? 'text-terminal-primary' : 'text-terminal-red'}>
+          Readiness: {pod.readiness?.status || 'unknown'}
+        </span>
+        <span className={pod.liveness?.status === 'passing' ? 'text-terminal-primary' : 'text-terminal-red'}>
+          Liveness: {pod.liveness?.status || 'unknown'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function EventRow({ event, isLast }) {
+  const isWarning = event.type === 'Warning'
+  const timeAgo = formatTimeAgo(event.lastTimestamp)
+
+  return (
+    <div className={`py-2 text-xs font-mono ${!isLast ? 'border-b border-terminal-border' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className={isWarning ? 'text-terminal-red' : 'text-terminal-primary'}>
+          {isWarning ? '\u25CB' : '\u25CF'}
+        </span>
+        <span className="text-terminal-muted">{timeAgo}</span>
+        <span className={isWarning ? 'text-terminal-secondary' : 'text-terminal-muted'}>
+          {event.reason}
+        </span>
+        {event.count > 1 && (
+          <span className="text-terminal-muted">(x{event.count})</span>
+        )}
+      </div>
+      <div className="ml-4 text-terminal-muted truncate" title={event.message}>
+        {event.message}
+      </div>
+    </div>
+  )
+}
+
+function formatTimeAgo(timestamp) {
+  if (!timestamp) return 'unknown'
+  const now = new Date()
+  const then = new Date(timestamp)
+  const seconds = Math.floor((now - then) / 1000)
+
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export function HealthStatus({ serviceId, fetchHealth, refreshInterval = 30000 }) {
+  const [health, setHealth] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!serviceId || !fetchHealth) return
+
+    let mounted = true
+
+    const loadHealth = async () => {
+      try {
+        const data = await fetchHealth(serviceId)
+        if (mounted) {
+          setHealth(data)
+          setError(null)
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(err.message || 'Failed to load health status')
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    // Initial load
+    loadHealth()
+
+    // Set up polling
+    const interval = setInterval(loadHealth, refreshInterval)
+
+    return () => {
+      mounted = false
+      clearInterval(interval)
+    }
+  }, [serviceId, fetchHealth, refreshInterval])
+
+  if (loading) {
+    return (
+      <AsciiBox title="Health Status" variant="cyan">
+        <div className="flex items-center justify-center py-4">
+          <TerminalSpinner color="cyan" />
+          <span className="ml-2 text-terminal-muted font-mono text-sm">Loading health status...</span>
+        </div>
+      </AsciiBox>
+    )
+  }
+
+  if (error) {
+    return (
+      <AsciiBox title="Health Status" variant="red">
+        <div className="text-center py-4">
+          <p className="font-mono text-terminal-red text-sm">! {error}</p>
+        </div>
+      </AsciiBox>
+    )
+  }
+
+  if (!health || !health.configured) {
+    return (
+      <AsciiBox title="Health Status" variant="cyan">
+        <div className="text-center py-4">
+          <p className="font-mono text-terminal-muted text-sm">
+            No health check configured for this service.
+          </p>
+          <p className="font-mono text-terminal-muted text-xs mt-2">
+            Configure a health check path in service settings to enable monitoring.
+          </p>
+        </div>
+      </AsciiBox>
+    )
+  }
+
+  const isHealthy = health.status === 'healthy'
+  const variant = isHealthy ? 'green' : 'red'
+
+  return (
+    <AsciiBox title="Health Status" variant={variant}>
+      {/* Current Status Header */}
+      <div className="flex items-center justify-between mb-4 pb-3 border-b border-terminal-border">
+        <div className="flex items-center gap-4">
+          <StatusIndicator
+            status={isHealthy ? 'online' : 'error'}
+            label={isHealthy ? 'HEALTHY' : 'UNHEALTHY'}
+          />
+          <span className="font-mono text-xs text-terminal-muted">
+            {health.path}
+          </span>
+        </div>
+        {health.activeCheck && (
+          <div className="font-mono text-sm">
+            <span className={isHealthy ? 'text-terminal-primary' : 'text-terminal-red'}>
+              {health.activeCheck.responseTimeMs}ms
+            </span>
+            {health.activeCheck.statusCode && (
+              <span className="text-terminal-muted ml-2">
+                HTTP {health.activeCheck.statusCode}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Active Check Status */}
+      {health.activeCheck && (
+        <div className="mb-4">
+          <div className="text-xs text-terminal-muted uppercase mb-2">Active Health Check</div>
+          <div className="font-mono text-sm">
+            <span className={health.activeCheck.status === 'healthy' ? 'text-terminal-primary' : 'text-terminal-red'}>
+              {health.activeCheck.status === 'healthy' ? '\u2713' : '\u2717'}
+            </span>
+            <span className="text-terminal-muted ml-2">
+              {health.activeCheck.status === 'healthy' ? 'Endpoint responding' : (health.activeCheck.error || 'Endpoint not responding')}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Pod Status */}
+      {health.pods && health.pods.length > 0 && (
+        <div className="mb-4 border-t border-terminal-border pt-3">
+          <div className="text-xs text-terminal-muted uppercase mb-2">
+            Pods ({health.pods.length})
+          </div>
+          {health.pods.map((pod, index) => (
+            <PodHealthRow
+              key={pod.name}
+              pod={pod}
+              isLast={index === health.pods.length - 1}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Response Time Chart */}
+      {health.history && health.history.length > 0 && (
+        <div className="mb-4 border-t border-terminal-border pt-3">
+          <ResponseTimeChart history={health.history} />
+        </div>
+      )}
+
+      {/* Recent Events */}
+      {health.events && health.events.length > 0 && (
+        <div className="border-t border-terminal-border pt-3">
+          <div className="text-xs text-terminal-muted uppercase mb-2">Recent Events</div>
+          {health.events.slice(0, 5).map((event, index) => (
+            <EventRow
+              key={`${event.lastTimestamp}-${index}`}
+              event={event}
+              isLast={index === Math.min(health.events.length, 5) - 1}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="text-xs text-terminal-muted mt-3 text-right">
+        Auto-refreshing every {refreshInterval / 1000}s
+      </div>
+    </AsciiBox>
+  )
+}
+
+export default HealthStatus

--- a/frontend/src/pages/ServiceDetail.jsx
+++ b/frontend/src/pages/ServiceDetail.jsx
@@ -10,7 +10,8 @@ import { BuildLogViewer } from '../components/BuildLogViewer'
 import { ResourceMetrics } from '../components/ResourceMetrics'
 import { DomainManager } from '../components/DomainManager'
 import { LogViewer } from '../components/LogViewer'
-import { fetchService, triggerDeploy, fetchWebhookSecret, restartService, fetchServiceMetrics, validateDockerfile } from '../api/services'
+import { HealthStatus } from '../components/HealthStatus'
+import { fetchService, triggerDeploy, fetchWebhookSecret, restartService, fetchServiceMetrics, validateDockerfile, fetchServiceHealth } from '../api/services'
 import { fetchEnvVars, createEnvVar, updateEnvVar, deleteEnvVar, revealEnvVar } from '../api/envVars'
 import { fetchDeployments } from '../api/deployments'
 import { ApiError } from '../api/utils'
@@ -24,6 +25,7 @@ export function ServiceDetail({ serviceId, onBack }) {
 
   const [configCollapsed, setConfigCollapsed] = useState(false)
   const [resourcesCollapsed, setResourcesCollapsed] = useState(false)
+  const [healthCollapsed, setHealthCollapsed] = useState(false)
   const [envCollapsed, setEnvCollapsed] = useState(false)
   const [webhooksCollapsed, setWebhooksCollapsed] = useState(false)
   const [domainsCollapsed, setDomainsCollapsed] = useState(false)
@@ -686,12 +688,34 @@ export function ServiceDetail({ serviceId, onBack }) {
         </div>
       )}
 
+      {/* Health Status Section */}
+      {service.health_check_path && (
+        <>
+          <AsciiSectionDivider
+            title="HEALTH STATUS"
+            collapsed={healthCollapsed}
+            onToggle={() => setHealthCollapsed(!healthCollapsed)}
+            color="green"
+          />
+
+          {!healthCollapsed && (
+            <div className="mt-4">
+              <HealthStatus
+                serviceId={serviceId}
+                fetchHealth={fetchServiceHealth}
+                refreshInterval={30000}
+              />
+            </div>
+          )}
+        </>
+      )}
+
       {/* Container Logs Section */}
       <AsciiSectionDivider
         title="CONTAINER LOGS"
         collapsed={containerLogsCollapsed}
         onToggle={() => setContainerLogsCollapsed(!containerLogsCollapsed)}
-        color="green"
+        color="cyan"
       />
 
       {!containerLogsCollapsed && (


### PR DESCRIPTION
## Summary

- Add comprehensive health check monitoring for services with configured health check paths
- Display real-time Kubernetes probe status (liveness/readiness)
- Perform active health checks against service endpoints
- Track response times with visual chart
- Show relevant pod events

## Changes

- **backend/migrations/008_create_health_checks.sql**: Add health_checks table with auto-cleanup
- **backend/src/services/kubernetes.js**: Add `getPodHealth` and `getPodEvents` functions
- **backend/src/services/healthChecker.js**: Create background health checker service
- **backend/src/routes/services.js**: Add `GET /services/:id/health` endpoint
- **frontend/src/api/services.js**: Add `fetchServiceHealth` API function
- **frontend/src/components/HealthStatus.jsx**: Create HealthStatus component with response time chart
- **frontend/src/pages/ServiceDetail.jsx**: Integrate health monitoring section

## Test plan

- [ ] Verify health status section appears for services with health_check_path configured
- [ ] Verify health status shows "not configured" for services without health_check_path
- [ ] Verify pod readiness/liveness status displays correctly
- [ ] Verify active health check runs and shows response time
- [ ] Verify response time chart renders with history data
- [ ] Verify auto-refresh updates health status every 30s
- [ ] Verify events section shows relevant pod events

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)