### PR TITLE
Add service cloning feature

### DIFF
--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -99,3 +99,20 @@ export async function fetchServiceLogs(id, options = {}) {
 export async function fetchServiceHealth(id) {
   return apiFetch(`/services/${id}/health`);
 }
+
+/**
+ * Clone an existing service
+ * @param {string} id - Source service ID
+ * @param {object} options - Clone options
+ * @param {string} options.name - New service name
+ * @param {string} options.project_id - Target project ID (optional, defaults to same project)
+ * @param {boolean} options.include_env - Copy environment variables (default false)
+ * @param {boolean} options.auto_deploy - Deploy immediately after cloning (default false)
+ * @returns {Promise<{service: object, deployment: object|null, cloned_from: string, env_vars_copied: boolean}>}
+ */
+export async function cloneService(id, options) {
+  return apiFetch(`/services/${id}/clone`, {
+    method: 'POST',
+    body: JSON.stringify(options),
+  });
+}

--- a/frontend/src/components/CloneServiceModal.jsx
+++ b/frontend/src/components/CloneServiceModal.jsx
@@ -1,0 +1,174 @@
+import { useState, useEffect } from 'react'
+import TerminalButton from './TerminalButton'
+import TerminalInput from './TerminalInput'
+import TerminalSelect from './TerminalSelect'
+import { fetchProjects } from '../api/projects'
+import { cloneService } from '../api/services'
+import { ApiError } from '../api/utils'
+
+export function CloneServiceModal({ service, onClose, onCloned }) {
+  const [name, setName] = useState(`${service.name}-copy`)
+  const [projectId, setProjectId] = useState(service.project_id)
+  const [includeEnv, setIncludeEnv] = useState(false)
+  const [autoDeploy, setAutoDeploy] = useState(false)
+  const [projects, setProjects] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [loadingProjects, setLoadingProjects] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        const projectList = await fetchProjects()
+        setProjects(projectList)
+      } catch (err) {
+        console.error('Failed to load projects:', err)
+      } finally {
+        setLoadingProjects(false)
+      }
+    }
+    loadProjects()
+  }, [])
+
+  const handleClone = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await cloneService(service.id, {
+        name: name.trim(),
+        project_id: projectId,
+        include_env: includeEnv,
+        auto_deploy: autoDeploy,
+      })
+      onCloned(result.service)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to clone service')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const projectOptions = projects.map(p => ({
+    value: p.id,
+    label: p.id === service.project_id ? `${p.name} (current)` : p.name
+  }))
+
+  return (
+    <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
+      <div className="w-full max-w-md mx-4">
+        <div className="font-mono whitespace-pre text-terminal-cyan select-none">
+          +-- CLONE SERVICE ---------------------------+
+        </div>
+        <div className="border-l border-r border-terminal-cyan bg-terminal-bg-secondary px-6 py-6">
+          <form onSubmit={handleClone}>
+            {/* Source Info */}
+            <div className="mb-4 pb-3 border-b border-terminal-border">
+              <span className="font-mono text-xs text-terminal-muted">CLONING FROM: </span>
+              <span className="font-mono text-sm text-terminal-primary">{service.name}</span>
+            </div>
+
+            {/* New Name */}
+            <div className="mb-4">
+              <label className="block font-mono text-xs text-terminal-muted uppercase mb-2">
+                New Name
+              </label>
+              <TerminalInput
+                value={name}
+                onChange={(e) => setName(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                placeholder="service-name"
+                className="w-full"
+                autoFocus
+              />
+            </div>
+
+            {/* Target Project */}
+            <div className="mb-4">
+              <label className="block font-mono text-xs text-terminal-muted uppercase mb-2">
+                Target Project
+              </label>
+              {loadingProjects ? (
+                <div className="font-mono text-sm text-terminal-muted py-2">Loading projects...</div>
+              ) : (
+                <TerminalSelect
+                  options={projectOptions}
+                  value={projectId}
+                  onChange={(e) => setProjectId(e.target.value)}
+                  className="w-full"
+                />
+              )}
+            </div>
+
+            {/* Options */}
+            <div className="mb-4 space-y-3">
+              <label className="flex items-center gap-3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={includeEnv}
+                  onChange={(e) => setIncludeEnv(e.target.checked)}
+                  className="w-4 h-4 accent-terminal-green bg-terminal-bg-secondary border border-terminal-border cursor-pointer"
+                />
+                <span className="font-mono text-sm text-terminal-primary group-hover:text-terminal-green transition-colors">
+                  Copy environment variables
+                </span>
+              </label>
+
+              <label className="flex items-center gap-3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={autoDeploy}
+                  onChange={(e) => setAutoDeploy(e.target.checked)}
+                  className="w-4 h-4 accent-terminal-green bg-terminal-bg-secondary border border-terminal-border cursor-pointer"
+                />
+                <span className="font-mono text-sm text-terminal-primary group-hover:text-terminal-green transition-colors">
+                  Deploy immediately after creation
+                </span>
+              </label>
+            </div>
+
+            {/* Warning for env vars */}
+            {includeEnv && (
+              <div className="mb-4 p-3 border border-terminal-yellow bg-terminal-yellow/10">
+                <span className="font-mono text-xs text-terminal-yellow">
+                  ! Environment variables will be copied with their current values. Review and update secrets in the new service.
+                </span>
+              </div>
+            )}
+
+            {/* Error */}
+            {error && (
+              <div className="mb-4 p-3 border border-terminal-red bg-terminal-red/10">
+                <span className="font-mono text-xs text-terminal-red">! {error}</span>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-end gap-3 mt-6">
+              <TerminalButton
+                type="button"
+                variant="secondary"
+                onClick={onClose}
+                disabled={loading}
+              >
+                [ CANCEL ]
+              </TerminalButton>
+              <TerminalButton
+                type="submit"
+                variant="primary"
+                disabled={loading || !name.trim()}
+              >
+                {loading ? '[ CLONING... ]' : '[ CLONE ]'}
+              </TerminalButton>
+            </div>
+          </form>
+        </div>
+        <div className="font-mono whitespace-pre text-terminal-cyan select-none">
+          +--------------------------------------------+
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CloneServiceModal

--- a/frontend/src/pages/ServiceDetail.jsx
+++ b/frontend/src/pages/ServiceDetail.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { AsciiBox } from '../components/AsciiBox'
 import { AsciiDivider, AsciiSectionDivider } from '../components/AsciiDivider'
 import { StatusIndicator } from '../components/StatusIndicator'
@@ -11,17 +12,20 @@ import { ResourceMetrics } from '../components/ResourceMetrics'
 import { DomainManager } from '../components/DomainManager'
 import { LogViewer } from '../components/LogViewer'
 import { HealthStatus } from '../components/HealthStatus'
+import { CloneServiceModal } from '../components/CloneServiceModal'
 import { fetchService, triggerDeploy, fetchWebhookSecret, restartService, fetchServiceMetrics, validateDockerfile, fetchServiceHealth } from '../api/services'
 import { fetchEnvVars, createEnvVar, updateEnvVar, deleteEnvVar, revealEnvVar } from '../api/envVars'
 import { fetchDeployments } from '../api/deployments'
 import { ApiError } from '../api/utils'
 
 export function ServiceDetail({ serviceId, onBack }) {
+  const navigate = useNavigate()
   const [service, setService] = useState(null)
   const [envVars, setEnvVars] = useState([])
   const [deployments, setDeployments] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [showCloneModal, setShowCloneModal] = useState(false)
 
   const [configCollapsed, setConfigCollapsed] = useState(false)
   const [resourcesCollapsed, setResourcesCollapsed] = useState(false)
@@ -452,6 +456,12 @@ export function ServiceDetail({ serviceId, onBack }) {
               {validating ? '[ VALIDATING... ]' : '[ VALIDATE DOCKERFILE ]'}
             </TerminalButton>
           )}
+          <TerminalButton
+            variant="secondary"
+            onClick={() => setShowCloneModal(true)}
+          >
+            [ CLONE ]
+          </TerminalButton>
           <TerminalButton
             variant="primary"
             onClick={handleTriggerDeploy}
@@ -1136,6 +1146,19 @@ export function ServiceDetail({ serviceId, onBack }) {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Clone Service Modal */}
+      {showCloneModal && (
+        <CloneServiceModal
+          service={service}
+          onClose={() => setShowCloneModal(false)}
+          onCloned={(newService) => {
+            setShowCloneModal(false)
+            toast.success(`Service cloned successfully as "${newService.name}"`)
+            navigate(`/services/${newService.id}`)
+          }}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Implements #73: Adds ability to clone an existing service to quickly create a new one with similar configuration
- Backend POST /services/:id/clone endpoint with validation and optional auto-deploy
- Frontend CloneServiceModal component with project selector and options
- Clone button integrated into ServiceDetail page

Closes #73

## Changes
- **Backend**: New `POST /services/:id/clone` endpoint in `services.js` that:
  - Validates service name and ownership
  - Supports cloning to same or different project
  - Optionally copies environment variables
  - Optionally triggers auto-deploy after cloning
  - Generates new webhook secret for cloned service
- **Frontend**: New `CloneServiceModal.jsx` component with:
  - Project selector dropdown
  - Options for copying env vars and auto-deploy
  - Warning message when copying env vars
  - Loading states and error handling
- **Frontend**: Added `cloneService()` function to services API
- **Frontend**: Integrated clone button and modal in `ServiceDetail.jsx`

## Test plan
- [ ] Open a service detail page and click the Clone button
- [ ] Verify the clone modal shows with source service name
- [ ] Enter a new name and verify validation works (lowercase, alphanumeric, hyphens)
- [ ] Test cloning to same project
- [ ] Test cloning to different project using the dropdown
- [ ] Test with "Copy environment variables" option enabled
- [ ] Test with "Deploy immediately" option enabled
- [ ] Verify navigation to new service after successful clone
- [ ] Verify error handling for duplicate service names

🤖 Generated with [Claude Code](https://claude.com/claude-code)