### PR TITLE
One-click deployment rollback

### DIFF
--- a/backend/migrations/009_add_rollback_tracking.sql
+++ b/backend/migrations/009_add_rollback_tracking.sql
@@ -1,0 +1,8 @@
+-- Migration: 009_add_rollback_tracking
+-- Description: Add rollback tracking to deployments table
+
+-- Add rollback_to column to track which deployment was rolled back to
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS rollback_to UUID REFERENCES deployments(id);
+
+-- Add index for rollback queries
+CREATE INDEX IF NOT EXISTS idx_deployments_rollback_to ON deployments(rollback_to);

--- a/backend/src/routes/deployments.js
+++ b/backend/src/routes/deployments.js
@@ -106,7 +106,7 @@ export default async function deploymentRoutes(fastify, options) {
     try {
       // Get deployments with pagination
       const result = await fastify.db.query(
-        `SELECT id, commit_sha, status, image_tag, created_at
+        `SELECT id, commit_sha, status, image_tag, rollback_to, created_at
          FROM deployments
          WHERE service_id = $1
          ORDER BY created_at DESC
@@ -167,6 +167,7 @@ export default async function deploymentRoutes(fastify, options) {
       status: deployment.status,
       image_tag: deployment.image_tag,
       build_logs: deployment.build_logs,
+      rollback_to: deployment.rollback_to,
       created_at: deployment.created_at,
     };
   });

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -138,3 +138,16 @@ export async function fixServicePort(id, port) {
     body: JSON.stringify(port ? { port } : {}),
   });
 }
+
+/**
+ * Rollback a service to a previous successful deployment
+ * @param {string} id - Service ID
+ * @param {string} deploymentId - Target deployment ID to rollback to
+ * @returns {Promise<{id: string, status: string, rollback_to: string, message: string}>}
+ */
+export async function rollbackService(id, deploymentId) {
+  return apiFetch(`/services/${id}/rollback`, {
+    method: 'POST',
+    body: JSON.stringify({ deployment_id: deploymentId }),
+  });
+}


### PR DESCRIPTION
## Summary
- Add database migration for `rollback_to` column in deployments table
- Add `POST /services/:id/rollback` endpoint to initiate rollback to a previous deployment
- Include `rollback_to` field in deployment list and detail responses
- Add `rollbackService` function to frontend API
- Add rollback UI with confirmation modal to ServiceDetail page
- Show rollback indicator (↩) in deployment history for rollback deployments
- Only allow rollback to previous successful (live) deployments with image_tag

## Test plan
- [ ] Trigger a deployment and wait for it to complete
- [ ] Trigger another deployment
- [ ] Verify rollback button appears on previous successful deployments
- [ ] Click rollback and confirm - verify new deployment is created quickly (no build)
- [ ] Verify deployment history shows rollback indicator (↩) for rollback deployments
- [ ] Verify rollback button is disabled during active deployments
- [ ] Verify cannot rollback to failed deployments or deployments without image_tag

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)