### PR TITLE
Add port auto-detection from Dockerfile EXPOSE directive

### DIFF
--- a/backend/migrations/009_add_detected_port.sql
+++ b/backend/migrations/009_add_detected_port.sql
@@ -1,0 +1,11 @@
+-- Add detected_port column to services table
+-- This stores the port detected from the Dockerfile EXPOSE directive
+
+ALTER TABLE services
+ADD COLUMN IF NOT EXISTS detected_port INTEGER;
+
+-- Add index for quick lookups of services with port mismatches
+CREATE INDEX IF NOT EXISTS idx_services_detected_port ON services(detected_port)
+WHERE detected_port IS NOT NULL;
+
+COMMENT ON COLUMN services.detected_port IS 'Port detected from Dockerfile EXPOSE directive';

--- a/backend/src/routes/services.js
+++ b/backend/src/routes/services.js
@@ -1,6 +1,6 @@
 import { generateWebhookSecret } from '../services/encryption.js';
-import { deleteDeployment, deleteService, deleteIngress, deletePVC, rolloutRestart, deleteServicePods, getPodMetrics, getDeployment, getPodsByLabel, getPodLogs, streamPodLogs, getPodHealth, getPodEvents } from '../services/kubernetes.js';
-import { getLatestCommit, getFileContent } from '../services/github.js';
+import { deleteDeployment, deleteService, deleteIngress, deletePVC, rolloutRestart, deleteServicePods, getPodMetrics, getDeployment, getPodsByLabel, getPodLogs, streamPodLogs, getPodHealth, getPodEvents, patchService, patchDeployment, patchIngress } from '../services/kubernetes.js';
+import { getLatestCommit, getFileContent, getDockerfileExposedPort } from '../services/github.js';
 import { decrypt, encrypt } from '../services/encryption.js';
 import { runBuildPipeline } from '../services/buildPipeline.js';
 import { validateDockerfile } from '../services/dockerfileValidator.js';
@@ -190,7 +190,7 @@ export default async function serviceRoutes(fastify, options) {
    */
   async function verifyServiceOwnership(serviceId, userId) {
     const result = await fastify.db.query(
-      `SELECT s.*, p.user_id, p.name as project_name
+      `SELECT s.*, s.detected_port, p.user_id, p.name as project_name
        FROM services s
        JOIN projects p ON s.project_id = p.id
        WHERE s.id = $1`,
@@ -564,6 +564,9 @@ export default async function serviceRoutes(fastify, options) {
       const webhookUrl = computeWebhookUrl(serviceId);
       const serviceUrl = computeServiceUrl(subdomain);
 
+      // Check for port mismatch
+      const hasMismatch = service.detected_port !== null && service.detected_port !== service.port;
+
       return {
         id: service.id,
         project_id: service.project_id,
@@ -574,6 +577,8 @@ export default async function serviceRoutes(fastify, options) {
         dockerfile_path: service.dockerfile_path,
         build_context: service.build_context,
         port: service.port,
+        detected_port: service.detected_port,
+        port_mismatch: hasMismatch,
         replicas: service.replicas,
         storage_gb: service.storage_gb,
         health_check_path: service.health_check_path,
@@ -1140,6 +1145,244 @@ export default async function serviceRoutes(fastify, options) {
       return reply.code(500).send({
         error: 'Internal Server Error',
         message: 'Failed to validate Dockerfile',
+      });
+    }
+  });
+
+  /**
+   * GET /services/:id/suggested-port
+   * Get the suggested port from Dockerfile EXPOSE directive
+   */
+  fastify.get('/services/:id/suggested-port', { schema: serviceParamsSchema }, async (request, reply) => {
+    const userId = request.user.id;
+    const serviceId = request.params.id;
+
+    // Verify ownership
+    const ownershipCheck = await verifyServiceOwnership(serviceId, userId);
+    if (ownershipCheck.error) {
+      return reply.code(ownershipCheck.status).send({
+        error: ownershipCheck.status === 404 ? 'Not Found' : 'Forbidden',
+        message: ownershipCheck.error,
+      });
+    }
+
+    const { service } = ownershipCheck;
+
+    // Cannot get suggested port for image-only services
+    if (!service.repo_url) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: 'Cannot detect port for image-only services',
+      });
+    }
+
+    try {
+      // Get user's GitHub token
+      const userResult = await fastify.db.query(
+        'SELECT github_access_token FROM users WHERE id = $1',
+        [userId]
+      );
+
+      if (!userResult.rows[0]?.github_access_token) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'GitHub token not configured',
+        });
+      }
+
+      const githubToken = decrypt(userResult.rows[0].github_access_token);
+
+      // Build the full Dockerfile path considering build_context
+      let dockerfilePath = service.dockerfile_path || 'Dockerfile';
+      if (service.build_context) {
+        const context = service.build_context.replace(/^\.\//, '').replace(/\/$/, '');
+        dockerfilePath = `${context}/${dockerfilePath}`;
+      }
+
+      // Fetch and parse Dockerfile
+      const { port: detectedPort } = await getDockerfileExposedPort(
+        githubToken,
+        service.repo_url,
+        dockerfilePath,
+        service.branch
+      );
+
+      // Update the detected_port in the database
+      if (detectedPort !== null) {
+        await fastify.db.query(
+          'UPDATE services SET detected_port = $1 WHERE id = $2',
+          [detectedPort, serviceId]
+        );
+      }
+
+      const hasMismatch = detectedPort !== null && detectedPort !== service.port;
+
+      return {
+        detected_port: detectedPort,
+        configured_port: service.port,
+        has_mismatch: hasMismatch,
+        dockerfile_path: dockerfilePath,
+      };
+    } catch (err) {
+      fastify.log.error(`Failed to get suggested port: ${err.message}`);
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to detect port from Dockerfile',
+      });
+    }
+  });
+
+  /**
+   * POST /services/:id/fix-port
+   * Update the service port to match the Dockerfile EXPOSE directive
+   * Updates both the database and Kubernetes resources without rebuild
+   */
+  fastify.post('/services/:id/fix-port', {
+    schema: {
+      ...serviceParamsSchema,
+      body: {
+        type: 'object',
+        properties: {
+          port: { type: 'integer', minimum: 1, maximum: 65535 }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const userId = request.user.id;
+    const userHash = request.user.hash;
+    const serviceId = request.params.id;
+    const { port: newPort } = request.body || {};
+
+    // Verify ownership
+    const ownershipCheck = await verifyServiceOwnership(serviceId, userId);
+    if (ownershipCheck.error) {
+      return reply.code(ownershipCheck.status).send({
+        error: ownershipCheck.status === 404 ? 'Not Found' : 'Forbidden',
+        message: ownershipCheck.error,
+      });
+    }
+
+    const { service } = ownershipCheck;
+    const namespace = computeNamespace(userHash, service.project_name);
+
+    // Determine the target port - use provided port or detected_port
+    let targetPort = newPort;
+    if (!targetPort) {
+      // Try to get detected port from database
+      const detectedResult = await fastify.db.query(
+        'SELECT detected_port FROM services WHERE id = $1',
+        [serviceId]
+      );
+      targetPort = detectedResult.rows[0]?.detected_port;
+    }
+
+    if (!targetPort) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: 'No port specified and no detected port available. Run suggested-port first or specify a port.',
+      });
+    }
+
+    if (targetPort === service.port) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: 'Port is already set to the specified value',
+      });
+    }
+
+    try {
+      // Update database first
+      await fastify.db.query(
+        'UPDATE services SET port = $1 WHERE id = $2',
+        [targetPort, serviceId]
+      );
+
+      // Update Kubernetes Service
+      try {
+        await patchService(namespace, service.name, {
+          spec: {
+            ports: [{
+              port: targetPort,
+              targetPort: targetPort,
+              protocol: 'TCP'
+            }]
+          }
+        });
+        fastify.log.info(`Patched K8s Service port for ${service.name} to ${targetPort}`);
+      } catch (k8sErr) {
+        if (k8sErr.status !== 404) {
+          fastify.log.warn(`Failed to patch K8s Service: ${k8sErr.message}`);
+        }
+      }
+
+      // Update Kubernetes Deployment container port
+      try {
+        await patchDeployment(namespace, service.name, {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: service.name,
+                  ports: [{
+                    containerPort: targetPort,
+                    protocol: 'TCP'
+                  }]
+                }]
+              }
+            }
+          }
+        });
+        fastify.log.info(`Patched K8s Deployment port for ${service.name} to ${targetPort}`);
+      } catch (k8sErr) {
+        if (k8sErr.status !== 404) {
+          fastify.log.warn(`Failed to patch K8s Deployment: ${k8sErr.message}`);
+        }
+      }
+
+      // Update Kubernetes Ingress backend port
+      try {
+        const subdomain = computeSubdomain(userHash, service.name);
+        await patchIngress(namespace, service.name, {
+          spec: {
+            rules: [{
+              host: `${subdomain}.${BASE_DOMAIN}`,
+              http: {
+                paths: [{
+                  path: '/',
+                  pathType: 'Prefix',
+                  backend: {
+                    service: {
+                      name: service.name,
+                      port: {
+                        number: targetPort
+                      }
+                    }
+                  }
+                }]
+              }
+            }]
+          }
+        });
+        fastify.log.info(`Patched K8s Ingress port for ${service.name} to ${targetPort}`);
+      } catch (k8sErr) {
+        if (k8sErr.status !== 404) {
+          fastify.log.warn(`Failed to patch K8s Ingress: ${k8sErr.message}`);
+        }
+      }
+
+      fastify.log.info(`Fixed port mismatch for service ${serviceId}: ${service.port} -> ${targetPort}`);
+
+      return {
+        success: true,
+        message: 'Port updated successfully',
+        previous_port: service.port,
+        new_port: targetPort,
+      };
+    } catch (err) {
+      fastify.log.error(`Failed to fix port: ${err.message}`);
+      return reply.code(500).send({
+        error: 'Internal Server Error',
+        message: 'Failed to update port',
       });
     }
   });

--- a/backend/src/services/kubernetes.js
+++ b/backend/src/services/kubernetes.js
@@ -216,6 +216,55 @@ export async function getDeployment(namespace, name) {
   return k8sRequest('GET', `/apis/apps/v1/namespaces/${namespace}/deployments/${name}`);
 }
 
+export async function getService(namespace, name) {
+  return k8sRequest('GET', `/api/v1/namespaces/${namespace}/services/${name}`);
+}
+
+/**
+ * Patch a Kubernetes Service using strategic merge patch
+ * @param {string} namespace - Namespace
+ * @param {string} name - Service name
+ * @param {object} patch - Patch object
+ */
+export async function patchService(namespace, name, patch) {
+  return k8sRequest(
+    'PATCH',
+    `/api/v1/namespaces/${namespace}/services/${name}`,
+    patch,
+    'application/strategic-merge-patch+json'
+  );
+}
+
+/**
+ * Patch a Kubernetes Deployment using strategic merge patch
+ * @param {string} namespace - Namespace
+ * @param {string} name - Deployment name
+ * @param {object} patch - Patch object
+ */
+export async function patchDeployment(namespace, name, patch) {
+  return k8sRequest(
+    'PATCH',
+    `/apis/apps/v1/namespaces/${namespace}/deployments/${name}`,
+    patch,
+    'application/strategic-merge-patch+json'
+  );
+}
+
+/**
+ * Patch a Kubernetes Ingress using strategic merge patch
+ * @param {string} namespace - Namespace
+ * @param {string} name - Ingress name
+ * @param {object} patch - Patch object
+ */
+export async function patchIngress(namespace, name, patch) {
+  return k8sRequest(
+    'PATCH',
+    `/apis/networking.k8s.io/v1/namespaces/${namespace}/ingresses/${name}`,
+    patch,
+    'application/strategic-merge-patch+json'
+  );
+}
+
 export async function getPodMetrics(namespace, labelSelector) {
   const metricsPath = `/apis/metrics.k8s.io/v1beta1/namespaces/${namespace}/pods`;
   const metrics = await k8sRequest('GET', metricsPath);

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -116,3 +116,25 @@ export async function cloneService(id, options) {
     body: JSON.stringify(options),
   });
 }
+
+/**
+ * Fetch suggested port from Dockerfile EXPOSE directive
+ * @param {string} id - Service ID
+ * @returns {Promise<{detected_port: number|null, configured_port: number, has_mismatch: boolean, dockerfile_path: string}>}
+ */
+export async function fetchSuggestedPort(id) {
+  return apiFetch(`/services/${id}/suggested-port`);
+}
+
+/**
+ * Fix port mismatch by updating service port to detected port
+ * @param {string} id - Service ID
+ * @param {number} port - Optional port to set (uses detected_port if not provided)
+ * @returns {Promise<{success: boolean, message: string, previous_port: number, new_port: number}>}
+ */
+export async function fixServicePort(id, port) {
+  return apiFetch(`/services/${id}/fix-port`, {
+    method: 'POST',
+    body: JSON.stringify(port ? { port } : {}),
+  });
+}


### PR DESCRIPTION
## Summary

- Add port auto-detection from Dockerfile EXPOSE directive during build and on-demand
- Show warning banner when detected port differs from configured port
- Add "Fix Port" button to update service port without triggering a rebuild

## Changes

### Backend
- **backend/src/services/github.js**: Add `parseDockerfileExpose()` and `getDockerfileExposedPort()` functions
- **backend/src/services/buildPipeline.js**: Add `detectDockerfilePort()` for build-time detection, log port mismatches
- **backend/src/services/kubernetes.js**: Add `patchService()`, `patchDeployment()`, `patchIngress()` for port updates
- **backend/src/routes/services.js**: 
  - Add `GET /services/:id/suggested-port` endpoint to detect port from Dockerfile
  - Add `POST /services/:id/fix-port` endpoint to update port without rebuild
  - Return `detected_port` and `port_mismatch` in service response
- **backend/migrations/009_add_detected_port.sql**: Add `detected_port` column to services table

### Frontend
- **frontend/src/api/services.js**: Add `fetchSuggestedPort()` and `fixServicePort()` API functions
- **frontend/src/pages/ServiceDetail.jsx**: Add port mismatch warning banner with "Fix Port" button

## Test plan

- [ ] Deploy a service with mismatched port configuration
- [ ] Verify warning banner appears showing the port mismatch
- [ ] Click "Fix Port" and verify port updates without rebuild
- [ ] Verify K8s Service, Deployment, and Ingress are patched
- [ ] Verify build logs show port mismatch warning when detected
- [ ] Verify service works correctly after port fix

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)