### PR TITLE
Add deployment notifications (webhook/email)

### DIFF
--- a/backend/migrations/009_create_notifications.sql
+++ b/backend/migrations/009_create_notifications.sql
@@ -1,0 +1,31 @@
+-- Notification preferences per user
+CREATE TABLE IF NOT EXISTS notification_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  email_enabled BOOLEAN DEFAULT false,
+  email_address VARCHAR(255),
+  webhook_enabled BOOLEAN DEFAULT false,
+  webhook_url TEXT,
+  webhook_secret VARCHAR(64),
+  notify_on_success BOOLEAN DEFAULT true,
+  notify_on_failure BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id)
+);
+
+-- Notification history
+CREATE TABLE IF NOT EXISTS notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  deployment_id UUID NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
+  type VARCHAR(20) NOT NULL, -- 'email', 'webhook'
+  status VARCHAR(20) NOT NULL, -- 'pending', 'sent', 'failed'
+  error TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  sent_at TIMESTAMPTZ
+);
+
+-- Index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_deployment_id ON notifications(deployment_id);

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "@octokit/rest": "^20.0.2",
     "fastify": "^4.24.3",
     "fastify-plugin": "^4.5.1",
+    "nodemailer": "^6.9.7",
     "pg": "^8.11.3",
     "yaml": "^2.3.4"
   },

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,212 @@
+import { sendTestNotification, generateWebhookSecret } from '../services/notifications.js';
+
+export default async function notificationRoutes(fastify, options) {
+  /**
+   * GET /notifications/settings
+   * Get notification settings for the current user
+   */
+  fastify.get('/notifications/settings', async (request, reply) => {
+    const userId = request.user.id;
+
+    const result = await fastify.db.query(
+      `SELECT
+        email_enabled, email_address,
+        webhook_enabled, webhook_url, webhook_secret,
+        notify_on_success, notify_on_failure,
+        created_at, updated_at
+       FROM notification_settings
+       WHERE user_id = $1`,
+      [userId]
+    );
+
+    if (result.rows.length === 0) {
+      return {
+        email_enabled: false,
+        email_address: null,
+        webhook_enabled: false,
+        webhook_url: null,
+        webhook_secret: null,
+        notify_on_success: true,
+        notify_on_failure: true,
+      };
+    }
+
+    return result.rows[0];
+  });
+
+  /**
+   * PUT /notifications/settings
+   * Update notification settings for the current user
+   */
+  fastify.put('/notifications/settings', {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          email_enabled: { type: 'boolean' },
+          email_address: { type: 'string', format: 'email', maxLength: 255 },
+          webhook_enabled: { type: 'boolean' },
+          webhook_url: { type: 'string', format: 'uri', maxLength: 2048 },
+          notify_on_success: { type: 'boolean' },
+          notify_on_failure: { type: 'boolean' },
+          regenerate_secret: { type: 'boolean' },
+        },
+      },
+    },
+  }, async (request, reply) => {
+    const userId = request.user.id;
+    const {
+      email_enabled,
+      email_address,
+      webhook_enabled,
+      webhook_url,
+      notify_on_success,
+      notify_on_failure,
+      regenerate_secret,
+    } = request.body;
+
+    // Check if settings exist
+    const existing = await fastify.db.query(
+      'SELECT webhook_secret FROM notification_settings WHERE user_id = $1',
+      [userId]
+    );
+
+    // Generate webhook secret if enabling webhooks or regenerating
+    let webhookSecret = existing.rows[0]?.webhook_secret;
+    if (webhook_enabled && (!webhookSecret || regenerate_secret)) {
+      webhookSecret = generateWebhookSecret();
+    }
+
+    if (existing.rows.length === 0) {
+      // Insert new settings
+      const result = await fastify.db.query(
+        `INSERT INTO notification_settings
+          (user_id, email_enabled, email_address, webhook_enabled, webhook_url,
+           webhook_secret, notify_on_success, notify_on_failure)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING
+           email_enabled, email_address,
+           webhook_enabled, webhook_url, webhook_secret,
+           notify_on_success, notify_on_failure`,
+        [
+          userId,
+          email_enabled ?? false,
+          email_address ?? null,
+          webhook_enabled ?? false,
+          webhook_url ?? null,
+          webhookSecret,
+          notify_on_success ?? true,
+          notify_on_failure ?? true,
+        ]
+      );
+
+      return result.rows[0];
+    } else {
+      // Update existing settings
+      const result = await fastify.db.query(
+        `UPDATE notification_settings SET
+          email_enabled = COALESCE($2, email_enabled),
+          email_address = COALESCE($3, email_address),
+          webhook_enabled = COALESCE($4, webhook_enabled),
+          webhook_url = COALESCE($5, webhook_url),
+          webhook_secret = COALESCE($6, webhook_secret),
+          notify_on_success = COALESCE($7, notify_on_success),
+          notify_on_failure = COALESCE($8, notify_on_failure),
+          updated_at = NOW()
+         WHERE user_id = $1
+         RETURNING
+           email_enabled, email_address,
+           webhook_enabled, webhook_url, webhook_secret,
+           notify_on_success, notify_on_failure`,
+        [
+          userId,
+          email_enabled,
+          email_address,
+          webhook_enabled,
+          webhook_url,
+          webhookSecret,
+          notify_on_success,
+          notify_on_failure,
+        ]
+      );
+
+      return result.rows[0];
+    }
+  });
+
+  /**
+   * POST /notifications/test
+   * Send a test notification
+   */
+  fastify.post('/notifications/test', async (request, reply) => {
+    const userId = request.user.id;
+
+    try {
+      const results = await sendTestNotification(fastify.db, userId);
+
+      if (Object.keys(results).length === 0) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'No notification channels enabled',
+        });
+      }
+
+      return { success: true, results };
+    } catch (error) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: error.message,
+      });
+    }
+  });
+
+  /**
+   * GET /notifications/history
+   * Get notification history for the current user
+   */
+  fastify.get('/notifications/history', {
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+          offset: { type: 'integer', minimum: 0, default: 0 },
+        },
+      },
+    },
+  }, async (request, reply) => {
+    const userId = request.user.id;
+    const { limit = 20, offset = 0 } = request.query;
+
+    const result = await fastify.db.query(
+      `SELECT
+        n.id, n.deployment_id, n.type, n.status, n.error, n.created_at, n.sent_at,
+        d.commit_sha, d.status as deployment_status,
+        s.name as service_name
+       FROM notifications n
+       JOIN deployments d ON n.deployment_id = d.id
+       JOIN services s ON d.service_id = s.id
+       WHERE n.user_id = $1
+       ORDER BY n.created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [userId, limit, offset]
+    );
+
+    const countResult = await fastify.db.query(
+      'SELECT COUNT(*) as total FROM notifications WHERE user_id = $1',
+      [userId]
+    );
+
+    const total = parseInt(countResult.rows[0].total, 10);
+
+    return {
+      notifications: result.rows,
+      pagination: {
+        total,
+        limit,
+        offset,
+        has_more: offset + result.rows.length < total,
+      },
+    };
+  });
+}

--- a/backend/src/routes/services.js
+++ b/backend/src/routes/services.js
@@ -991,6 +991,13 @@ export default async function serviceRoutes(fastify, options) {
         fastify.log.info(`Created deployment ${deployment.id} for service ${serviceId} at commit ${commitSha}`);
       }
 
+      // Construct project object for notifications
+      const project = {
+        id: service.project_id,
+        name: service.project_name,
+        user_id: service.user_id,
+      };
+
       // Trigger build pipeline asynchronously (don't await - runs in background)
       runBuildPipeline(
         fastify.db,
@@ -999,7 +1006,8 @@ export default async function serviceRoutes(fastify, options) {
         commitSha,
         githubToken,
         namespace,
-        userHash
+        userHash,
+        project
       ).catch(err => {
         fastify.log.error(`Build pipeline failed for deployment ${deployment.id}: ${err.message}`);
       });
@@ -2155,6 +2163,13 @@ export default async function serviceRoutes(fastify, options) {
           }
         }
 
+        // Construct project object for notifications
+        const project = {
+          id: targetProjectId,
+          name: projectName,
+          user_id: userId,
+        };
+
         // Trigger build pipeline asynchronously
         runBuildPipeline(
           fastify.db,
@@ -2163,7 +2178,8 @@ export default async function serviceRoutes(fastify, options) {
           commitSha || 'clone-deploy',
           githubToken,
           namespace,
-          userHash
+          userHash,
+          project
         ).catch(err => {
           fastify.log.error(`Build pipeline failed for cloned service ${newService.id}: ${err.message}`);
         });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,7 @@ import deploymentRoutes from './routes/deployments.js';
 import webhookRoutes from './routes/webhooks.js';
 import githubRoutes from './routes/github.js';
 import domainRoutes from './routes/domains.js';
+import notificationRoutes from './routes/notifications.js';
 
 const fastify = Fastify({
   logger: true,
@@ -105,6 +106,9 @@ fastify.register(githubRoutes);
 
 // Register domain routes
 fastify.register(domainRoutes);
+
+// Register notification routes
+fastify.register(notificationRoutes);
 
 // Routes that do not require authentication
 const publicRoutes = [

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -1,0 +1,307 @@
+import nodemailer from 'nodemailer';
+import crypto from 'crypto';
+import logger from './logger.js';
+
+/**
+ * Send deployment notification (webhook and/or email) based on user preferences
+ * @param {object} db - Database connection
+ * @param {object} deployment - Deployment object with status
+ * @param {object} service - Service object
+ * @param {object} project - Project object with user_id
+ */
+export async function sendDeploymentNotification(db, deployment, service, project) {
+  const settings = await db.query(
+    'SELECT * FROM notification_settings WHERE user_id = $1',
+    [project.user_id]
+  );
+
+  if (!settings.rows[0]) {
+    logger.debug('No notification settings found for user', { userId: project.user_id });
+    return;
+  }
+
+  const prefs = settings.rows[0];
+  const isSuccess = deployment.status === 'live';
+
+  // Check if user wants this type of notification
+  if (isSuccess && !prefs.notify_on_success) {
+    logger.debug('User disabled success notifications', { userId: project.user_id });
+    return;
+  }
+  if (!isSuccess && !prefs.notify_on_failure) {
+    logger.debug('User disabled failure notifications', { userId: project.user_id });
+    return;
+  }
+
+  const payload = {
+    event: 'deployment.completed',
+    deployment: {
+      id: deployment.id,
+      status: deployment.status,
+      commit_sha: deployment.commit_sha,
+      created_at: deployment.created_at,
+    },
+    service: {
+      id: service.id,
+      name: service.name,
+      url: service.url || null,
+    },
+    project: {
+      id: project.id,
+      name: project.name,
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  // Send webhook notification
+  if (prefs.webhook_enabled && prefs.webhook_url) {
+    await sendWebhook(db, project.user_id, deployment.id, prefs, payload);
+  }
+
+  // Send email notification
+  if (prefs.email_enabled && prefs.email_address) {
+    await sendEmail(db, project.user_id, deployment.id, prefs, payload, service);
+  }
+}
+
+/**
+ * Send webhook notification
+ */
+async function sendWebhook(db, userId, deploymentId, prefs, payload) {
+  const signature = crypto
+    .createHmac('sha256', prefs.webhook_secret || '')
+    .update(JSON.stringify(payload))
+    .digest('hex');
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+    const response = await fetch(prefs.webhook_url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Dangus-Signature': `sha256=${signature}`,
+        'X-Dangus-Event': 'deployment.completed',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    await db.query(
+      `INSERT INTO notifications (user_id, deployment_id, type, status, sent_at)
+       VALUES ($1, $2, 'webhook', 'sent', NOW())`,
+      [userId, deploymentId]
+    );
+
+    logger.info('Webhook notification sent', { userId, deploymentId, url: prefs.webhook_url });
+  } catch (error) {
+    const errorMessage = error.name === 'AbortError' ? 'Request timed out' : error.message;
+
+    await db.query(
+      `INSERT INTO notifications (user_id, deployment_id, type, status, error)
+       VALUES ($1, $2, 'webhook', 'failed', $3)`,
+      [userId, deploymentId, errorMessage]
+    );
+
+    logger.error('Webhook notification failed', { userId, deploymentId, error: errorMessage });
+  }
+}
+
+/**
+ * Send email notification
+ */
+async function sendEmail(db, userId, deploymentId, prefs, payload, service) {
+  // Check if SMTP is configured
+  if (!process.env.SMTP_HOST) {
+    logger.warn('SMTP not configured, skipping email notification');
+    await db.query(
+      `INSERT INTO notifications (user_id, deployment_id, type, status, error)
+       VALUES ($1, $2, 'email', 'failed', $3)`,
+      [userId, deploymentId, 'SMTP not configured']
+    );
+    return;
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: process.env.SMTP_USER ? {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    } : undefined,
+  });
+
+  const statusEmoji = payload.deployment.status === 'live' ? '✅' : '❌';
+  const statusText = payload.deployment.status === 'live' ? 'succeeded' : 'failed';
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || '"Dangus Cloud" <notifications@dangus.cloud>',
+      to: prefs.email_address,
+      subject: `${statusEmoji} Deployment ${statusText}: ${service.name}`,
+      html: `
+        <div style="font-family: monospace; background: #0a0a0a; color: #00ff00; padding: 20px; border: 1px solid #00ff00;">
+          <h2 style="color: ${payload.deployment.status === 'live' ? '#00ff00' : '#ff0000'};">
+            Deployment ${statusText}
+          </h2>
+          <p><strong>Service:</strong> ${service.name}</p>
+          <p><strong>Project:</strong> ${payload.project.name}</p>
+          <p><strong>Status:</strong> ${payload.deployment.status}</p>
+          <p><strong>Commit:</strong> ${payload.deployment.commit_sha || 'N/A'}</p>
+          ${service.url ? `<p><strong>URL:</strong> <a href="${service.url}" style="color: #00ff00;">${service.url}</a></p>` : ''}
+          <p style="margin-top: 20px;">
+            <a href="${frontendUrl}/services/${service.id}" style="color: #00ff00; border: 1px solid #00ff00; padding: 10px 20px; text-decoration: none;">
+              View in Dashboard
+            </a>
+          </p>
+        </div>
+      `,
+      text: `
+Deployment ${statusText}
+
+Service: ${service.name}
+Project: ${payload.project.name}
+Status: ${payload.deployment.status}
+Commit: ${payload.deployment.commit_sha || 'N/A'}
+${service.url ? `URL: ${service.url}` : ''}
+
+View in Dashboard: ${frontendUrl}/services/${service.id}
+      `.trim(),
+    });
+
+    await db.query(
+      `INSERT INTO notifications (user_id, deployment_id, type, status, sent_at)
+       VALUES ($1, $2, 'email', 'sent', NOW())`,
+      [userId, deploymentId]
+    );
+
+    logger.info('Email notification sent', { userId, deploymentId, to: prefs.email_address });
+  } catch (error) {
+    await db.query(
+      `INSERT INTO notifications (user_id, deployment_id, type, status, error)
+       VALUES ($1, $2, 'email', 'failed', $3)`,
+      [userId, deploymentId, error.message]
+    );
+
+    logger.error('Email notification failed', { userId, deploymentId, error: error.message });
+  }
+}
+
+/**
+ * Send a test notification to verify settings
+ * @param {object} db - Database connection
+ * @param {string} userId - User ID
+ * @returns {Promise<{webhook?: {success: boolean, error?: string}, email?: {success: boolean, error?: string}}>}
+ */
+export async function sendTestNotification(db, userId) {
+  const settings = await db.query(
+    'SELECT * FROM notification_settings WHERE user_id = $1',
+    [userId]
+  );
+
+  if (!settings.rows[0]) {
+    throw new Error('No notification settings configured');
+  }
+
+  const prefs = settings.rows[0];
+  const results = {};
+
+  const testPayload = {
+    event: 'test',
+    message: 'This is a test notification from Dangus Cloud',
+    timestamp: new Date().toISOString(),
+  };
+
+  // Test webhook
+  if (prefs.webhook_enabled && prefs.webhook_url) {
+    const signature = crypto
+      .createHmac('sha256', prefs.webhook_secret || '')
+      .update(JSON.stringify(testPayload))
+      .digest('hex');
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const response = await fetch(prefs.webhook_url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Dangus-Signature': `sha256=${signature}`,
+          'X-Dangus-Event': 'test',
+        },
+        body: JSON.stringify(testPayload),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      results.webhook = { success: true };
+    } catch (error) {
+      results.webhook = {
+        success: false,
+        error: error.name === 'AbortError' ? 'Request timed out' : error.message,
+      };
+    }
+  }
+
+  // Test email
+  if (prefs.email_enabled && prefs.email_address) {
+    if (!process.env.SMTP_HOST) {
+      results.email = { success: false, error: 'SMTP not configured' };
+    } else {
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: parseInt(process.env.SMTP_PORT || '587', 10),
+        secure: process.env.SMTP_SECURE === 'true',
+        auth: process.env.SMTP_USER ? {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        } : undefined,
+      });
+
+      try {
+        await transporter.sendMail({
+          from: process.env.SMTP_FROM || '"Dangus Cloud" <notifications@dangus.cloud>',
+          to: prefs.email_address,
+          subject: 'Test Notification - Dangus Cloud',
+          html: `
+            <div style="font-family: monospace; background: #0a0a0a; color: #00ff00; padding: 20px; border: 1px solid #00ff00;">
+              <h2 style="color: #00ff00;">Test Notification</h2>
+              <p>Your email notifications are configured correctly.</p>
+              <p style="color: #888;">Sent at: ${new Date().toISOString()}</p>
+            </div>
+          `,
+          text: 'Test Notification\n\nYour email notifications are configured correctly.',
+        });
+
+        results.email = { success: true };
+      } catch (error) {
+        results.email = { success: false, error: error.message };
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Generate a new webhook secret
+ * @returns {string} 64-character hex string
+ */
+export function generateWebhookSecret() {
+  return crypto.randomBytes(32).toString('hex');
+}

--- a/frontend/src/api/notifications.js
+++ b/frontend/src/api/notifications.js
@@ -1,0 +1,42 @@
+import { apiFetch } from './utils';
+
+/**
+ * Get notification settings for the current user
+ * @returns {Promise<object>} Notification settings
+ */
+export async function getNotificationSettings() {
+  return apiFetch('/notifications/settings');
+}
+
+/**
+ * Update notification settings
+ * @param {object} settings - Settings to update
+ * @returns {Promise<object>} Updated settings
+ */
+export async function updateNotificationSettings(settings) {
+  return apiFetch('/notifications/settings', {
+    method: 'PUT',
+    body: JSON.stringify(settings),
+  });
+}
+
+/**
+ * Send a test notification
+ * @returns {Promise<object>} Test results
+ */
+export async function sendTestNotification() {
+  return apiFetch('/notifications/test', {
+    method: 'POST',
+  });
+}
+
+/**
+ * Get notification history
+ * @param {object} params - Pagination params
+ * @param {number} params.limit - Number of items per page
+ * @param {number} params.offset - Offset for pagination
+ * @returns {Promise<object>} Notification history with pagination
+ */
+export async function getNotificationHistory({ limit = 20, offset = 0 } = {}) {
+  return apiFetch(`/notifications/history?limit=${limit}&offset=${offset}`);
+}


### PR DESCRIPTION
## Summary
- Add deployment notification system with webhook and email support
- Users can configure notification preferences in Settings page
- Notifications are sent when deployments complete (success or failure)
- Webhook includes HMAC signature for verification

## Changes
- Database migration for notification_settings and notifications tables
- Notification service with webhook and email sending
- API routes for managing notification settings
- Frontend UI for configuring notifications in Settings
- Integration with deployment workflow to trigger notifications

## Test plan
- [ ] Create notification settings (email/webhook)
- [ ] Trigger a deployment and verify notification is sent
- [ ] Test webhook signature verification
- [ ] Test the "Send Test" button
- [ ] View notification history in settings

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)