### PR TITLE
Fix lossy path encoding in debug agent ConfigMap

### DIFF
--- a/backend/src/services/debugAgent.js
+++ b/backend/src/services/debugAgent.js
@@ -354,8 +354,9 @@ async function rebuildWithChanges(db, service, deployment, fileChanges, githubTo
   const configMapData = {};
 
   for (const file of fileChanges) {
-    // Escape path: src/nginx.conf -> src_nginx.conf
-    const key = file.path.replace(/\//g, '_');
+    // Encode path: escape underscores first, then convert slashes
+    // e.g., src/my_config.js -> src_my__config.js
+    const key = file.path.replace(/_/g, '__').replace(/\//g, '_');
     configMapData[key] = file.content;
   }
 

--- a/templates/kaniko-job-generated.yaml.tpl
+++ b/templates/kaniko-job-generated.yaml.tpl
@@ -93,9 +93,10 @@ spec:
               for file in /generated/*; do
                 if [ -f "$file" ]; then
                   filename=$(basename "$file")
-                  # Convert underscores back to slashes for nested paths
-                  # e.g., src_nginx.conf -> src/nginx.conf
-                  destpath=$(echo "$filename" | sed 's/_/\//g')
+                  # Decode path: convert single underscores to slashes, then double to single
+                  # e.g., src_my__config.js -> src/my_config.js
+                  # Uses null byte as temp placeholder to avoid double-replacement
+                  destpath=$(echo "$filename" | sed 's/__/\x00/g; s/_/\//g; s/\x00/_/g')
                   # Security: Reject paths with .. or starting with /
                   if echo "$destpath" | grep -qE '(^/|\.\.)'; then
                     echo "SECURITY: Rejecting invalid path: $destpath"

--- a/test-encoding.sh
+++ b/test-encoding.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Test encoding/decoding roundtrip
+
+test_roundtrip() {
+    local input="$1"
+    local expected="$2"
+
+    # Encode: escape underscores first, then convert slashes
+    encoded=$(echo "$input" | sed 's/_/__/g; s/\//_/g')
+    # Decode: convert single underscores to slashes, then double to single
+    decoded=$(echo "$encoded" | sed 's/__/\x00/g; s/_/\//g; s/\x00/_/g')
+
+    if [ "$decoded" = "$expected" ]; then
+        echo "PASS: $input -> $encoded -> $decoded"
+    else
+        echo "FAIL: $input -> $encoded -> $decoded (expected: $expected)"
+        exit 1
+    fi
+}
+
+test_security() {
+    local input="$1"
+    local should_block="$2"
+
+    # Encode then decode
+    encoded=$(echo "$input" | sed 's/_/__/g; s/\//_/g')
+    decoded=$(echo "$encoded" | sed 's/__/\x00/g; s/_/\//g; s/\x00/_/g')
+
+    if echo "$decoded" | grep -qE '(^/|\.\.)'; then
+        blocked="yes"
+    else
+        blocked="no"
+    fi
+
+    if [ "$blocked" = "$should_block" ]; then
+        echo "PASS: Security check for '$input' (blocked=$blocked)"
+    else
+        echo "FAIL: Security check for '$input' (blocked=$blocked, expected=$should_block)"
+        exit 1
+    fi
+}
+
+echo "=== Roundtrip Tests ==="
+test_roundtrip "src/config/app.js" "src/config/app.js"
+test_roundtrip "src/my_config.js" "src/my_config.js"
+test_roundtrip "Dockerfile" "Dockerfile"
+test_roundtrip "config/my_app_config.json" "config/my_app_config.json"
+test_roundtrip "deep/path/with_underscore/file_name.js" "deep/path/with_underscore/file_name.js"
+
+echo ""
+echo "=== Security Tests ==="
+test_security "../../../etc/passwd" "yes"
+test_security "/etc/passwd" "yes"
+test_security "src/normal/file.js" "no"
+test_security "my_config.js" "no"
+
+echo ""
+echo "All tests passed!"


### PR DESCRIPTION
## Summary
Fix the path encoding scheme that was corrupting filenames containing underscores.

## Changes
- Encode literal underscores as `__` before converting `/` to `_`
- Decode using null byte as intermediate to avoid conflicts
- Added test script to verify encoding/decoding

## Before
`my_config.js` → `my_config.js` → `my/config.js` (BROKEN)

## After  
`my_config.js` → `my__config.js` → `my_config.js` (CORRECT)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)