### PR TITLE
Add Kubernetes job termination on debug session cancel

### DIFF
--- a/backend/migrations/013_add_debug_job_tracking.sql
+++ b/backend/migrations/013_add_debug_job_tracking.sql
@@ -1,0 +1,5 @@
+-- Track current Kaniko job for debug sessions to enable cancellation
+-- Issue #90: Add Kubernetes job termination on debug session cancel
+
+ALTER TABLE debug_sessions ADD COLUMN current_job_name VARCHAR(255);
+ALTER TABLE debug_sessions ADD COLUMN current_namespace VARCHAR(255);


### PR DESCRIPTION
## Summary
When a user cancels a debug session, actually terminate the running Kaniko job.

## Changes
- Add `current_job_name` and `current_namespace` columns to track running jobs
- Store job info after triggering debug build
- Delete Kaniko job when session is cancelled
- Job deletion is non-blocking with error logging

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)