### PR TITLE
Fix circular import in debug agent

### DIFF
--- a/backend/src/routes/deployments.js
+++ b/backend/src/routes/deployments.js
@@ -1,6 +1,9 @@
 import { getPodsByLabel, streamPodLogs } from '../services/kubernetes.js';
+import { getLatestDeployment, updateDeploymentStatus } from '../services/deploymentService.js';
 
-const DEPLOYMENT_STATUSES = ['pending', 'building', 'deploying', 'live', 'failed'];
+// Re-export for backwards compatibility (though consumers should import from deploymentService directly)
+export { getLatestDeployment, updateDeploymentStatus };
+
 const DEFAULT_PAGE_LIMIT = 20;
 
 export default async function deploymentRoutes(fastify, options) {
@@ -358,71 +361,3 @@ export default async function deploymentRoutes(fastify, options) {
   });
 }
 
-/**
- * Helper to get the latest deployment for a service
- * @param {object} db - Database connection
- * @param {string} serviceId - Service UUID
- * @returns {object|null} Latest deployment or null
- */
-export async function getLatestDeployment(db, serviceId) {
-  const result = await db.query(
-    `SELECT id, commit_sha, status, image_tag, build_logs, created_at
-     FROM deployments
-     WHERE service_id = $1
-     ORDER BY created_at DESC
-     LIMIT 1`,
-    [serviceId]
-  );
-
-  return result.rows[0] || null;
-}
-
-/**
- * Helper to update deployment status (used by build pipeline)
- * @param {object} db - Database connection
- * @param {string} deploymentId - Deployment UUID
- * @param {string} status - New status (pending, building, deploying, live, failed)
- * @param {object} extras - Optional additional fields to update
- * @param {string} extras.build_logs - Build logs to append/set
- * @param {string} extras.image_tag - Docker image tag
- * @returns {object} Updated deployment
- */
-export async function updateDeploymentStatus(db, deploymentId, status, extras = {}) {
-  if (!DEPLOYMENT_STATUSES.includes(status)) {
-    throw new Error(`Invalid deployment status: ${status}. Must be one of: ${DEPLOYMENT_STATUSES.join(', ')}`);
-  }
-
-  const { build_logs, image_tag } = extras;
-
-  const setClauses = ['status = $1'];
-  const values = [status];
-  let paramIndex = 2;
-
-  if (build_logs !== undefined) {
-    setClauses.push(`build_logs = $${paramIndex}`);
-    values.push(build_logs);
-    paramIndex++;
-  }
-
-  if (image_tag !== undefined) {
-    setClauses.push(`image_tag = $${paramIndex}`);
-    values.push(image_tag);
-    paramIndex++;
-  }
-
-  values.push(deploymentId);
-
-  const result = await db.query(
-    `UPDATE deployments
-     SET ${setClauses.join(', ')}
-     WHERE id = $${paramIndex}
-     RETURNING id, service_id, commit_sha, status, image_tag, build_logs, created_at`,
-    values
-  );
-
-  if (result.rows.length === 0) {
-    throw new Error(`Deployment not found: ${deploymentId}`);
-  }
-
-  return result.rows[0];
-}

--- a/backend/src/services/buildPipeline.js
+++ b/backend/src/services/buildPipeline.js
@@ -20,7 +20,7 @@ import {
 } from './manifestGenerator.js';
 import { parseGitHubUrl, getDockerfileExposedPort } from './github.js';
 import { getGeneratedFile } from './dockerfileGenerator.js';
-import { updateDeploymentStatus } from '../routes/deployments.js';
+import { updateDeploymentStatus } from './deploymentService.js';
 import { decrypt } from './encryption.js';
 import { sendDeploymentNotification } from './notifications.js';
 import appEvents from './event-emitter.js';

--- a/backend/src/services/debugAgent.js
+++ b/backend/src/services/debugAgent.js
@@ -3,7 +3,7 @@ import { getRepoTree, getFileContent, parseGitHubUrl } from './github.js';
 import { getGeneratedFile } from './dockerfileGenerator.js';
 import { upsertConfigMap, deleteConfigMap } from './kubernetes.js';
 import { triggerBuild, watchBuildJob, captureBuildLogs, deployService, getDecryptedEnvVars } from './buildPipeline.js';
-import { updateDeploymentStatus } from '../routes/deployments.js';
+import { updateDeploymentStatus } from './deploymentService.js';
 import appEvents from './event-emitter.js';
 import logger from './logger.js';
 

--- a/backend/src/services/deploymentService.js
+++ b/backend/src/services/deploymentService.js
@@ -1,0 +1,74 @@
+/**
+ * Deployment service - shared deployment operations used by routes and services
+ */
+
+const DEPLOYMENT_STATUSES = ['pending', 'building', 'deploying', 'live', 'failed'];
+
+/**
+ * Helper to get the latest deployment for a service
+ * @param {object} db - Database connection
+ * @param {string} serviceId - Service UUID
+ * @returns {object|null} Latest deployment or null
+ */
+export async function getLatestDeployment(db, serviceId) {
+  const result = await db.query(
+    `SELECT id, commit_sha, status, image_tag, build_logs, created_at
+     FROM deployments
+     WHERE service_id = $1
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [serviceId]
+  );
+
+  return result.rows[0] || null;
+}
+
+/**
+ * Helper to update deployment status (used by build pipeline)
+ * @param {object} db - Database connection
+ * @param {string} deploymentId - Deployment UUID
+ * @param {string} status - New status (pending, building, deploying, live, failed)
+ * @param {object} extras - Optional additional fields to update
+ * @param {string} extras.build_logs - Build logs to append/set
+ * @param {string} extras.image_tag - Docker image tag
+ * @returns {object} Updated deployment
+ */
+export async function updateDeploymentStatus(db, deploymentId, status, extras = {}) {
+  if (!DEPLOYMENT_STATUSES.includes(status)) {
+    throw new Error(`Invalid deployment status: ${status}. Must be one of: ${DEPLOYMENT_STATUSES.join(', ')}`);
+  }
+
+  const { build_logs, image_tag } = extras;
+
+  const setClauses = ['status = $1'];
+  const values = [status];
+  let paramIndex = 2;
+
+  if (build_logs !== undefined) {
+    setClauses.push(`build_logs = $${paramIndex}`);
+    values.push(build_logs);
+    paramIndex++;
+  }
+
+  if (image_tag !== undefined) {
+    setClauses.push(`image_tag = $${paramIndex}`);
+    values.push(image_tag);
+    paramIndex++;
+  }
+
+  values.push(deploymentId);
+
+  const result = await db.query(
+    `UPDATE deployments
+     SET ${setClauses.join(', ')}
+     WHERE id = $${paramIndex}
+     RETURNING id, service_id, commit_sha, status, image_tag, build_logs, created_at`,
+    values
+  );
+
+  if (result.rows.length === 0) {
+    throw new Error(`Deployment not found: ${deploymentId}`);
+  }
+
+  return result.rows[0];
+}


### PR DESCRIPTION
## Summary
Refactor to eliminate circular import between services and routes.

## Changes
- Create `backend/src/services/deploymentService.js` with shared functions
- Move `updateDeploymentStatus` and `getLatestDeployment` to service
- Update imports in `debugAgent.js` and `buildPipeline.js`
- Re-export from `routes/deployments.js` for backward compatibility

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)