### PR TITLE
Fix unused onComplete prop in DebugSessionViewer

### DIFF
--- a/frontend/src/components/DebugSessionViewer.jsx
+++ b/frontend/src/components/DebugSessionViewer.jsx
@@ -64,6 +64,13 @@ export function DebugSessionViewer({
     }
   }, [session.status, sessionId]);
 
+  // Notify parent when session reaches terminal state
+  useEffect(() => {
+    if (session.isComplete()) {
+      onComplete(session);
+    }
+  }, [session.status, onComplete, session]);
+
   // Handle cancel
   const handleCancel = async () => {
     try {

--- a/frontend/src/pages/service/ServiceOverview.jsx
+++ b/frontend/src/pages/service/ServiceOverview.jsx
@@ -63,6 +63,7 @@ export function ServiceOverview({
             sessionId={activeDebugSession.id}
             serviceUrl={service.url}
             onRetry={onDebugRetry}
+            onComplete={() => onRefresh?.()}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
Implements the unused `onComplete` prop in DebugSessionViewer so parent components are notified when a debug session completes.

## Changes
- Add useEffect in DebugSessionViewer that calls `onComplete` when session reaches terminal state (succeeded, failed, or cancelled)
- Wire up `onComplete` in ServiceOverview to trigger `onRefresh`, ensuring the service data refreshes after a debug session ends

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)