### PR TITLE
Add rollback functionality for debug sessions

### DIFF
--- a/frontend/src/api/debug.js
+++ b/frontend/src/api/debug.js
@@ -52,6 +52,17 @@ export async function retryDebugSession(sessionId) {
 }
 
 /**
+ * Rollback a debug session to restore original files
+ * @param {string} sessionId - Debug session UUID
+ * @returns {Promise<{success: boolean, sessionId: string, restoredFiles: string[]}>}
+ */
+export async function rollbackDebugSession(sessionId) {
+  return apiFetch(`/debug-sessions/${sessionId}/rollback`, {
+    method: 'POST',
+  });
+}
+
+/**
  * Get active or most recent debug session for a service
  * @param {string} serviceId - Service UUID
  * @returns {Promise<{session: object | null}>}


### PR DESCRIPTION
## Summary

Adds the ability to rollback debug session changes and restore the original files that were snapshotted when the debug session started.

## Changes

- Add `rollbackDebugSession()` function in `backend/src/services/debugAgent.js` to restore original files from session snapshot
- Add `POST /debug-sessions/:sessionId/rollback` endpoint in `backend/src/routes/debug.js`
- Add `rollbackDebugSession` API call in `frontend/src/api/debug.js`
- Add rollback button to `DebugSessionViewer.jsx` success state
- Session status updated to `rolled_back` after rollback
- Show confirmation message after successful rollback

## Testing

1. Complete a successful debug session (AI modified files)
2. Click "ROLLBACK" button on the success screen
3. Verify original Dockerfile is restored in generated_files table
4. Trigger a new deployment
5. Verify it uses the original (pre-debug) Dockerfile

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)