### PR TITLE
Surface token/cost tracking in debug session UI

### DIFF
--- a/frontend/src/components/DebugSessionViewer.jsx
+++ b/frontend/src/components/DebugSessionViewer.jsx
@@ -190,6 +190,16 @@ const [copySuccess, setCopySuccess] = useState(false);
     );
   }
 
+  // Helper to render token/cost info
+  const renderTokenInfo = () => {
+    if (!session.totalTokens || session.totalTokens === 0) return null;
+    return (
+      <div className="font-mono text-xs text-terminal-muted border-t border-terminal-border pt-2 mt-2">
+        Tokens: {session.totalTokens.toLocaleString()} | Est. cost: ${session.estimatedCost}
+      </div>
+    );
+  };
+
   // SUCCESS STATE
   if (session.isSucceeded()) {
     // Show rolled back confirmation
@@ -250,6 +260,8 @@ const [copySuccess, setCopySuccess] = useState(false);
               {rollingBack ? '[ ROLLING BACK... ]' : '[ ROLLBACK ]'}
             </TerminalButton>
           </div>
+
+          {renderTokenInfo()}
         </div>
       </TerminalCard>
     );
@@ -291,6 +303,8 @@ const [copySuccess, setCopySuccess] = useState(false);
                 [ VIEW ALL {session.maxAttempts} ATTEMPTS ]
               </TerminalButton>
             </div>
+
+            {renderTokenInfo()}
           </div>
         </TerminalCard>
 
@@ -321,6 +335,8 @@ const [copySuccess, setCopySuccess] = useState(false);
               {retrying ? '[ STARTING... ]' : '[ TRY AGAIN ]'}
             </TerminalButton>
           </div>
+
+          {renderTokenInfo()}
         </div>
       </TerminalCard>
     );

--- a/frontend/src/hooks/useDebugSession.js
+++ b/frontend/src/hooks/useDebugSession.js
@@ -18,6 +18,8 @@ export function useDebugSession(sessionId, initialSession = null) {
   const [finalExplanation, setFinalExplanation] = useState(initialSession?.finalExplanation || null);
   const [message, setMessage] = useState(null);
   const [lastUpdate, setLastUpdate] = useState(null);
+  const [totalTokens, setTotalTokens] = useState(initialSession?.totalTokens || 0);
+  const [estimatedCost, setEstimatedCost] = useState(initialSession?.estimatedCost || '0.0000');
 
   const { subscribe, isConnected } = useWebSocket();
 
@@ -49,6 +51,12 @@ export function useDebugSession(sessionId, initialSession = null) {
       }
       if (payload.message) {
         setMessage(payload.message);
+      }
+      if (payload.totalTokens !== undefined) {
+        setTotalTokens(payload.totalTokens);
+      }
+      if (payload.estimatedCost !== undefined) {
+        setEstimatedCost(payload.estimatedCost);
       }
       setLastUpdate(timestamp || new Date().toISOString());
     });
@@ -118,6 +126,8 @@ export function useDebugSession(sessionId, initialSession = null) {
     finalExplanation,
     message,
     lastUpdate,
+    totalTokens,
+    estimatedCost,
 
     // Helpers
     isRunning,


### PR DESCRIPTION
## Summary
Display token usage and estimated cost for AI debug sessions so users have visibility into API costs.

## Changes
- Add `totalTokens` and `estimatedCost` fields to `/debug-sessions/:sessionId` and `/services/:serviceId/debug-session` API responses
- Add `calculateEstimatedCost()` helper using $18/1M tokens blended rate
- Update `useDebugSession` hook to track token/cost state
- Display token count and estimated cost in success, failed, and cancelled states
- Show per-attempt token count in the attempt history view

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)