### PR TITLE
feat: Expand debug agent to handle runtime failures

### DIFF
--- a/backend/src/routes/debug.js
+++ b/backend/src/routes/debug.js
@@ -169,10 +169,12 @@ export default async function debugRoutes(fastify, options) {
 
     const { deployment } = ownershipCheck;
 
-    // Check deployment is in failed state
-    if (deployment.status !== 'failed') {
+    // Check deployment is in a debuggable state (failed build or runtime issues)
+    // Allow: 'failed' (build failure), 'running' (runtime crash), 'deployed' (health issues)
+    const debuggableStatuses = ['failed', 'running', 'deployed'];
+    if (!debuggableStatuses.includes(deployment.status)) {
       return reply.code(400).send({
-        error: 'Can only debug failed deployments',
+        error: 'Can only debug failed or running deployments with issues',
         currentStatus: deployment.status,
       });
     }

--- a/backend/src/services/debugAgent.js
+++ b/backend/src/services/debugAgent.js
@@ -229,10 +229,11 @@ export async function runDebugLoop(db, session, service, deployment, githubToken
           maxAttempts: session.max_attempts,
           status: 'needs_manual_fix',
           explanation: llmResult.explanation,
+          suggestedActions: llmResult.suggestedActions || [],
           message: 'Issue requires manual fix by the user'
         });
 
-        return { success: false, attempts: attempt, needsManualFix: true, explanation: llmResult.explanation };
+        return { success: false, attempts: attempt, needsManualFix: true, explanation: llmResult.explanation, suggestedActions: llmResult.suggestedActions || [] };
       }
 
       // Emit progress - applying changes

--- a/frontend/src/components/DebugSessionViewer.jsx
+++ b/frontend/src/components/DebugSessionViewer.jsx
@@ -267,6 +267,56 @@ const [copySuccess, setCopySuccess] = useState(false);
     );
   }
 
+  // NEEDS MANUAL FIX STATE
+  if (session.needsManualFix()) {
+    return (
+      <TerminalCard title="MANUAL FIX REQUIRED" variant="amber" glow className={className}>
+        <div className="space-y-4">
+          <div className="text-terminal-secondary font-mono text-sm">
+            The AI determined this issue requires manual intervention.
+          </div>
+
+          {session.explanation && (
+            <TerminalSection
+              title="ANALYSIS"
+              variant="amber"
+              defaultCollapsed={false}
+            >
+              <pre className="text-terminal-muted text-xs whitespace-pre-wrap">
+                {session.explanation}
+              </pre>
+            </TerminalSection>
+          )}
+
+          {session.suggestedActions && session.suggestedActions.length > 0 && (
+            <TerminalSection
+              title="SUGGESTED ACTIONS"
+              variant="cyan"
+              defaultCollapsed={false}
+            >
+              <ul className="text-terminal-muted text-xs space-y-1 list-disc list-inside">
+                {session.suggestedActions.map((action, idx) => (
+                  <li key={idx}>{action}</li>
+                ))}
+              </ul>
+            </TerminalSection>
+          )}
+
+          <div className="flex justify-center gap-4 pt-2">
+            <TerminalButton
+              variant="secondary"
+              onClick={() => setShowHistoryModal(true)}
+            >
+              [ VIEW ATTEMPTS ]
+            </TerminalButton>
+          </div>
+
+          {renderTokenInfo()}
+        </div>
+      </TerminalCard>
+    );
+  }
+
   // FAILED STATE
   if (session.isFailed()) {
     return (

--- a/frontend/src/hooks/useDebugSession.js
+++ b/frontend/src/hooks/useDebugSession.js
@@ -20,6 +20,7 @@ export function useDebugSession(sessionId, initialSession = null) {
   const [lastUpdate, setLastUpdate] = useState(null);
   const [totalTokens, setTotalTokens] = useState(initialSession?.totalTokens || 0);
   const [estimatedCost, setEstimatedCost] = useState(initialSession?.estimatedCost || '0.0000');
+  const [suggestedActions, setSuggestedActions] = useState(initialSession?.suggestedActions || []);
 
   const { subscribe, isConnected } = useWebSocket();
 
@@ -128,6 +129,7 @@ export function useDebugSession(sessionId, initialSession = null) {
     lastUpdate,
     totalTokens,
     estimatedCost,
+    suggestedActions,
 
     // Helpers
     isRunning,

--- a/frontend/src/hooks/useDebugSession.js
+++ b/frontend/src/hooks/useDebugSession.js
@@ -59,6 +59,9 @@ export function useDebugSession(sessionId, initialSession = null) {
       if (payload.estimatedCost !== undefined) {
         setEstimatedCost(payload.estimatedCost);
       }
+      if (payload.suggestedActions) {
+        setSuggestedActions(payload.suggestedActions);
+      }
       setLastUpdate(timestamp || new Date().toISOString());
     });
 
@@ -106,7 +109,7 @@ export function useDebugSession(sessionId, initialSession = null) {
    * Check if session is in a terminal state
    */
   const isComplete = useCallback(() => {
-    return ['succeeded', 'failed', 'cancelled', 'error'].includes(status);
+    return ['succeeded', 'failed', 'cancelled', 'error', 'needs_manual_fix'].includes(status);
   }, [status]);
 
   /**


### PR DESCRIPTION
## Summary
- Added `determineFailurePhase` and `gatherDiagnosticContext` functions to debugAgent.js to detect failure phase (build/startup/runtime/health)
- Updated system prompt to be generalist, handling all failure phases with rich context
- Expanded kubernetes.js with pod state detection (waitingReason, terminatedReason, exitCode) and `getDeploymentSpec` function
- Modified debug routes to allow debugging running/deployed services (not just failed builds)
- Added `needsManualFix` UI state with `suggestedActions` array for user guidance
- Updated useDebugSession hook to track suggestedActions via WebSocket

## Test plan
- [ ] Deploy a service that fails at build time - verify debug agent works as before
- [ ] Deploy a service that crashes at startup (CrashLoopBackOff) - verify phase detection and context gathering
- [ ] Test manual fix flow with suggested actions UI
- [ ] Verify token/cost tracking still works

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)